### PR TITLE
Fix FileObject path resolution fallback and bump version to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/FileObject.js
+++ b/src/lib/FileObject.js
@@ -68,7 +68,7 @@ export default class FileObject {
 
     const final = path.isAbsolute(fixedFile)
       ? fixedFile
-      : path.resolve(directory.path, fixedFile)
+      : path.resolve(directory?.path ?? ".", fixedFile)
 
     const resolved = final
     const fileUri = File.pathToUri(resolved)


### PR DESCRIPTION
# Fix path resolution in FileObject

This PR addresses an issue in the `FileObject` class where path resolution would fail when `directory` is undefined. The fix adds a fallback to the current directory (".") when `directory?.path` is null or undefined, ensuring the path resolution works correctly in all scenarios.

Also bumps the package version from 0.0.9 to 0.0.10.