### PR TITLE
Move fdType constants to FS class and bump version to 0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Core file system abstractions
 export {default as FileObject} from "./lib/FileObject.js"
 export {default as DirectoryObject} from "./lib/DirectoryObject.js"
-export {default as FS, fdType, upperFdTypes, fdTypes} from "./lib/FS.js"
+export {default as FS} from "./lib/FS.js"
 
 // Utility classes
 export {default as Cache} from "./lib/Cache.js"

--- a/src/lib/FS.js
+++ b/src/lib/FS.js
@@ -12,9 +12,11 @@ const fdTypes = Object.freeze(["file", "directory"])
 const upperFdTypes = Object.freeze(fdTypes.map(type => type.toUpperCase()))
 const fdType = Object.freeze(await Data.allocateObject(upperFdTypes, fdTypes))
 
-export {fdType, upperFdTypes, fdTypes}
-
 export default class FS {
+  static fdTypes = fdTypes
+  static upperFdTypes = upperFdTypes
+  static fdType = fdType
+
   /**
    * Fix slashes in a path
    *

--- a/src/types/FS.d.ts
+++ b/src/types/FS.d.ts
@@ -8,6 +8,15 @@ import DirectoryObject from './DirectoryObject.js'
  * Base filesystem utilities class. FileObject and DirectoryObject extend this class.
  */
 export default class FS {
+  /** Array of lowercase file descriptor types */
+  static readonly fdTypes: readonly ["file", "directory"]
+
+  /** Array of uppercase file descriptor types */
+  static readonly upperFdTypes: readonly ["FILE", "DIRECTORY"]
+
+  /** Mapping from uppercase to lowercase file descriptor types */
+  static readonly fdType: Readonly<Record<"FILE" | "DIRECTORY", "file" | "directory">>
+
   /** Fix slashes in a path */
   static fixSlashes(pathName: string): string
 
@@ -29,18 +38,3 @@ export default class FS {
   /** Resolve a path relative to another path using various strategies. Handles absolute paths, relative navigation, and overlap-based merging */
   static resolvePath(fromPath: string, toPath: string): string
 }
-
-/**
- * File descriptor types as lowercase strings
- */
-export const fdTypes: readonly ["file", "directory"]
-
-/**
- * File descriptor types as uppercase strings
- */
-export const upperFdTypes: readonly ["FILE", "DIRECTORY"]
-
-/**
- * Mapping from uppercase file descriptor types to lowercase
- */
-export const fdType: Readonly<Record<"FILE" | "DIRECTORY", "file" | "directory">>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -2,7 +2,7 @@
 // Core file system abstractions
 export { default as FileObject } from './FileObject.js'
 export { default as DirectoryObject } from './DirectoryObject.js'
-export { default as FS, fdType, upperFdTypes, fdTypes } from './FS.js'
+export { default as FS } from './FS.js'
 
 // Utility classes
 export { default as Cache } from './Cache.js'

--- a/tests/unit/Cache.test.js
+++ b/tests/unit/Cache.test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import {describe, it, before, after, beforeEach} from 'node:test'
 import assert from 'node:assert/strict'
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import {after,before,beforeEach,describe,it} from 'node:test'
 
 import Cache from '../../src/lib/Cache.js'
 import FileObject from '../../src/lib/FileObject.js'
@@ -24,11 +24,11 @@ describe('Cache', () => {
     yamlFile = new FileObject('palette.yaml', fixturesDir)
     brokenJsonFile = new FileObject('broken.json5', fixturesDir)
     brokenYamlFile = new FileObject('broken.yaml', fixturesDir)
-    
+
     // Create a temporary directory for test files that need modification
     testDir = path.join(process.cwd(), 'test-cache-files')
     await fs.mkdir(testDir, { recursive: true })
-    
+
     nonExistentFile = new FileObject(path.join(testDir, 'does-not-exist.json'))
   })
 
@@ -63,7 +63,7 @@ describe('Cache', () => {
   describe('loadCachedData', () => {
     it('loads and caches JSON data', async () => {
       const data = await cache.loadCachedData(jsonFile)
-      
+
       assert.equal(typeof data, 'object')
       assert.equal(data['eslint.format.enable'], true)
       assert.equal(data['editor.formatOnSave'], true)
@@ -72,7 +72,7 @@ describe('Cache', () => {
 
     it('loads and caches YAML data', async () => {
       const data = await cache.loadCachedData(yamlFile)
-      
+
       assert.equal(typeof data, 'object')
       assert.ok(data.vars)
       assert.ok(data.vars.colors)
@@ -83,10 +83,10 @@ describe('Cache', () => {
     it('returns cached data on subsequent calls', async () => {
       // First call - loads from file
       const data1 = await cache.loadCachedData(jsonFile)
-      
+
       // Second call - should return cached data
       const data2 = await cache.loadCachedData(jsonFile)
-      
+
       assert.deepEqual(data1, data2)
       assert.equal(data1['editor.tabSize'], 2)
     })
@@ -108,7 +108,7 @@ describe('Cache', () => {
       const originalContent = await fs.readFile(jsonFile.path, 'utf8')
       await fs.writeFile(copyPath, originalContent)
       const modifiableFile = new FileObject(copyPath)
-      
+
       // Load initial data
       const initialData = await cache.loadCachedData(modifiableFile)
       assert.equal(initialData['editor.tabSize'], 2)
@@ -136,7 +136,7 @@ describe('Cache', () => {
       // Both should be cached independently
       assert.equal(jsonData['editor.tabSize'], 2)
       assert.equal(yamlData.vars.colors.black, 'oklch(.145 0 0)')
-      
+
       // They have different structures
       assert.ok(jsonData['eslint.format.enable']) // JSON has this
       assert.equal(yamlData['eslint.format.enable'], undefined) // YAML doesn't
@@ -146,12 +146,12 @@ describe('Cache', () => {
   describe('cache consistency', () => {
     it('handles race conditions gracefully', async () => {
       // Simulate concurrent access
-      const promises = Array(5).fill(null).map(() => 
+      const promises = Array(5).fill(null).map(() =>
         cache.loadCachedData(jsonFile)
       )
 
       const results = await Promise.all(promises)
-      
+
       // All results should be identical
       results.forEach(result => {
         assert.deepEqual(result, results[0])
@@ -163,7 +163,7 @@ describe('Cache', () => {
       const copyPath = path.join(testDir, 'cleanup-test.json')
       await fs.writeFile(copyPath, '{"initial": true}')
       const modifiableFile = new FileObject(copyPath)
-      
+
       // Load data to populate cache
       await cache.loadCachedData(modifiableFile)
 
@@ -181,10 +181,10 @@ describe('Cache', () => {
     it('handles corrupted cache state gracefully', async () => {
       // This test simulates a scenario where modification time exists
       // but cached data doesn't (which shouldn't happen normally)
-      
+
       // Load data first to populate cache
       await cache.loadCachedData(jsonFile)
-      
+
       // File should load normally
       const data = await cache.loadCachedData(jsonFile)
       assert.equal(typeof data, 'object')
@@ -220,7 +220,7 @@ describe('Cache', () => {
           message: /Content is neither valid JSON5 nor valid YAML/
         }
       )
-      
+
       await assert.rejects(
         () => cache.loadCachedData(brokenYamlFile),
         {

--- a/tests/unit/Data.test.js
+++ b/tests/unit/Data.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import {describe,it} from "node:test"
 
-import { Data, Sass, Type } from "../../src/index.js"
+import {Data,Sass,Type} from "../../src/index.js"
 
 describe("Data", () => {
   describe("static properties", () => {
@@ -84,7 +84,7 @@ describe("Data", () => {
       assert.deepEqual(Data.arrayPad([1, 2], 4, 0), [0, 0, 1, 2]) // prepend by default
       assert.deepEqual(Data.arrayPad([1, 2], 4, 0, -1), [1, 2, 0, 0]) // append
       assert.deepEqual(Data.arrayPad([1, 2, 3], 2, 0), [1, 2, 3]) // no change if already long enough
-      
+
       assert.throws(() => {
         Data.arrayPad([1, 2], 4, 0, 1) // invalid position
       }, Sass)
@@ -99,7 +99,7 @@ describe("Data", () => {
       assert.deepEqual(cloned, original)
       assert.notStrictEqual(cloned, original)
       assert.notStrictEqual(cloned.b, original.b)
-      
+
       // Modify original to verify independence
       original.b.c = 99
       assert.equal(cloned.b.c, 2) // unchanged
@@ -124,7 +124,7 @@ describe("Data", () => {
     it("assureObjectPath creates nested structure", () => {
       const obj = {}
       const result = Data.assureObjectPath(obj, ["a", "b", "c"])
-      
+
       assert.deepEqual(obj, { a: { b: { c: {} } } })
       assert.strictEqual(result, obj.a.b.c)
     })
@@ -132,9 +132,9 @@ describe("Data", () => {
     it("setNestedValue sets deep property values", () => {
       const obj = {}
       Data.setNestedValue(obj, ["a", "b", "c"], "value")
-      
+
       assert.deepEqual(obj, { a: { b: { c: "value" } } })
-      
+
       // Update existing path
       Data.setNestedValue(obj, ["a", "b", "d"], "other")
       assert.equal(obj.a.b.d, "other")
@@ -147,7 +147,7 @@ describe("Data", () => {
 
       const expected = { a: 1, b: { c: 4, d: 3, e: 5 }, f: 6 }
       assert.deepEqual(result, expected)
-      
+
       // Arrays are replaced, not merged
       const arr1 = { a: [1, 2] }
       const arr2 = { a: [3, 4] }
@@ -205,7 +205,7 @@ describe("Data", () => {
   describe("mapObject", () => {
     it("transforms object values with async function", async () => {
       const original = { a: 1, b: 2, c: { d: 3 } }
-      const transformer = async (key, value) => 
+      const transformer = async (key, value) =>
         typeof value === "number" ? value * 2 : value
 
       const result = await Data.mapObject(original, transformer)
@@ -291,13 +291,13 @@ describe("Data", () => {
       assert.equal(Data.isEmpty("   "), true) // whitespace-only
       assert.equal(Data.isEmpty([]), true)
       assert.equal(Data.isEmpty({}), true)
-      
+
       // Non-empty values
       assert.equal(Data.isEmpty("hello"), false)
       assert.equal(Data.isEmpty([1]), false)
       assert.equal(Data.isEmpty({ a: 1 }), false)
       assert.equal(Data.isEmpty(0), false) // number not emptyable
-      
+
       // Without checkForNothing
       assert.equal(Data.isEmpty(null, false), false)
       assert.equal(Data.isEmpty(undefined, false), false)

--- a/tests/unit/DirectoryObject.test.js
+++ b/tests/unit/DirectoryObject.test.js
@@ -1,10 +1,10 @@
-import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert/strict"
-import path from "node:path"
 import fs from "node:fs/promises"
+import path from "node:path"
+import {afterEach,beforeEach,describe,it} from "node:test"
 
-import { DirectoryObject, Sass } from "../../src/index.js"
-import { TestUtils } from "../helpers/test-utils.js"
+import {DirectoryObject,Sass} from "../../src/index.js"
+import {TestUtils} from "../helpers/test-utils.js"
 
 describe("DirectoryObject", () => {
   let testDir
@@ -12,7 +12,7 @@ describe("DirectoryObject", () => {
   describe("constructor and basic properties", () => {
     it("creates DirectoryObject with valid directory", () => {
       const dir = new DirectoryObject("/home/user/test")
-      
+
       assert.ok(dir instanceof DirectoryObject)
       assert.equal(typeof dir.supplied, "string")
       assert.equal(typeof dir.path, "string")
@@ -22,14 +22,14 @@ describe("DirectoryObject", () => {
 
     it("handles relative paths", () => {
       const dir = new DirectoryObject("../test")
-      
+
       assert.ok(path.isAbsolute(dir.path))
       assert.equal(dir.supplied, "../test")
     })
 
     it("handles current directory", () => {
       const dir = new DirectoryObject(".")
-      
+
       assert.equal(dir.supplied, ".")
       assert.equal(dir.name, path.basename(process.cwd()))
     })
@@ -37,14 +37,14 @@ describe("DirectoryObject", () => {
     it("handles null/undefined input", () => {
       const dir1 = new DirectoryObject(null)
       const dir2 = new DirectoryObject(undefined)
-      
+
       assert.equal(dir1.supplied, ".")
       assert.equal(dir2.supplied, ".")
     })
 
     it("fixes slashes in paths", () => {
       const dir = new DirectoryObject("path\\\\with\\\\backslashes")
-      
+
       assert.ok(!dir.supplied.includes("\\\\"))
       assert.ok(dir.supplied.includes("/"))
     })
@@ -95,7 +95,7 @@ describe("DirectoryObject", () => {
     it("toString returns formatted string", () => {
       const dir = new DirectoryObject("/test/path")
       const str = dir.toString()
-      
+
       assert.ok(str.includes("DirectoryObject"))
       assert.ok(str.includes(dir.path))
     })
@@ -103,7 +103,7 @@ describe("DirectoryObject", () => {
     it("toJSON returns object representation", () => {
       const dir = new DirectoryObject("/test/path")
       const json = dir.toJSON()
-      
+
       assert.equal(typeof json, "object")
       assert.ok("supplied" in json)
       assert.ok("path" in json)
@@ -113,7 +113,7 @@ describe("DirectoryObject", () => {
       assert.ok("extension" in json)
       assert.ok("isFile" in json)
       assert.ok("isDirectory" in json)
-      
+
       assert.equal(json.isFile, false)
       assert.equal(json.isDirectory, true)
     })
@@ -156,11 +156,11 @@ describe("DirectoryObject", () => {
     beforeEach(async () => {
       testDir = await TestUtils.createTestDir("dir-read-test")
       testDirObj = new DirectoryObject(testDir)
-      
+
       // Create subdirectory and file for testing
       subDir = path.join(testDir, "subdir")
       await fs.mkdir(subDir)
-      
+
       testFile = path.join(testDir, "test.txt")
       await fs.writeFile(testFile, "test content")
     })
@@ -173,7 +173,7 @@ describe("DirectoryObject", () => {
 
     it("returns files and directories", async () => {
       const result = await testDirObj.read(testDirObj)
-      
+
       assert.ok(Array.isArray(result.files))
       assert.ok(Array.isArray(result.directories))
       assert.equal(result.files.length, 1)
@@ -182,14 +182,14 @@ describe("DirectoryObject", () => {
 
     it("returned files are FileObject instances", async () => {
       const { files } = await testDirObj.read(testDirObj)
-      
+
       // Note: This might fail due to circular import
       assert.ok(files[0].constructor.name === "FileObject")
     })
 
     it("returned directories are DirectoryObject instances", async () => {
       const { directories } = await testDirObj.read(testDirObj)
-      
+
       assert.ok(directories[0] instanceof DirectoryObject)
     })
 
@@ -197,7 +197,7 @@ describe("DirectoryObject", () => {
       const emptyDir = path.join(testDir, "empty")
       await fs.mkdir(emptyDir)
       const emptyDirObj = new DirectoryObject(emptyDir)
-      
+
       const result = await emptyDirObj.read(emptyDirObj)
       assert.equal(result.files.length, 0)
       assert.equal(result.directories.length, 0)
@@ -221,25 +221,25 @@ describe("DirectoryObject", () => {
 
     it("creates directory if it doesn't exist", async () => {
       assert.equal(await testDirObj.exists, false)
-      
+
       await testDirObj.assureExists()
-      
+
       assert.equal(await testDirObj.exists, true)
     })
 
     it("doesn't throw if directory already exists", async () => {
       await testDirObj.assureExists()
-      
+
       // Should not throw
       await testDirObj.assureExists()
-      
+
       assert.equal(await testDirObj.exists, true)
     })
 
     it("handles nested directory creation", async () => {
       const nestedPath = path.join(testDir, "level1", "level2", "level3")
       const nestedDir = new DirectoryObject(nestedPath)
-      
+
       // This might fail without recursive option
       try {
         await nestedDir.assureExists({ recursive: true })
@@ -254,7 +254,7 @@ describe("DirectoryObject", () => {
       // Try to create directory in non-existent parent without recursive
       const invalidPath = path.join(testDir, "nonexistent", "subdir")
       const invalidDir = new DirectoryObject(invalidPath)
-      
+
       await assert.rejects(
         () => invalidDir.assureExists(),
         Sass
@@ -265,7 +265,7 @@ describe("DirectoryObject", () => {
   describe("edge cases and error handling", () => {
     it("handles special characters in path", () => {
       const dir = new DirectoryObject("/test/path with spaces/and-dashes")
-      
+
       assert.ok(dir.path.includes("spaces"))
       assert.ok(dir.path.includes("dashes"))
     })
@@ -273,13 +273,13 @@ describe("DirectoryObject", () => {
     it("handles very long paths", () => {
       const longPath = "/test/" + "a".repeat(200) + "/dir"
       const dir = new DirectoryObject(longPath)
-      
+
       assert.ok(dir.path.includes("a".repeat(200)))
     })
 
     it("meta object is frozen", () => {
       const dir = new DirectoryObject("/test")
-      
+
       // Should not be able to modify internal meta
       assert.throws(() => {
         dir.supplied = "modified"  // This should fail

--- a/tests/unit/FS.test.js
+++ b/tests/unit/FS.test.js
@@ -1,33 +1,33 @@
-import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert/strict"
 import path from "node:path"
+import {afterEach,beforeEach,describe,it} from "node:test"
 
-import { FS, FileObject, Sass, fdType, upperFdTypes, fdTypes } from "../../src/index.js"
-import { TestUtils } from "../helpers/test-utils.js"
+import {FS,FileObject,Sass} from "../../src/index.js"
+import {TestUtils} from "../helpers/test-utils.js"
 
 describe("FS", () => {
 
   describe("file descriptor types", () => {
     it("fdTypes contains expected lowercase types", () => {
-      assert.deepEqual(fdTypes, ["file", "directory"])
-      assert.ok(Object.isFrozen(fdTypes))
+      assert.deepEqual(FS.fdTypes, ["file", "directory"])
+      assert.ok(Object.isFrozen(FS.fdTypes))
     })
 
     it("upperFdTypes contains expected uppercase types", () => {
-      assert.deepEqual(upperFdTypes, ["FILE", "DIRECTORY"])
-      assert.ok(Object.isFrozen(upperFdTypes))
+      assert.deepEqual(FS.upperFdTypes, ["FILE", "DIRECTORY"])
+      assert.ok(Object.isFrozen(FS.upperFdTypes))
     })
 
     it("fdType maps uppercase to lowercase types", () => {
-      assert.equal(fdType.FILE, "file")
-      assert.equal(fdType.DIRECTORY, "directory")
-      assert.ok(Object.isFrozen(fdType))
+      assert.equal(FS.fdType.FILE, "file")
+      assert.equal(FS.fdType.DIRECTORY, "directory")
+      assert.ok(Object.isFrozen(FS.fdType))
     })
 
     it("fdType has correct structure", () => {
-      assert.equal(Object.keys(fdType).length, 2)
-      assert.ok("FILE" in fdType)
-      assert.ok("DIRECTORY" in fdType)
+      assert.equal(Object.keys(FS.fdType).length, 2)
+      assert.ok("FILE" in FS.fdType)
+      assert.ok("DIRECTORY" in FS.fdType)
     })
   })
 

--- a/tests/unit/FileObject.test.js
+++ b/tests/unit/FileObject.test.js
@@ -1,10 +1,10 @@
-import { describe, it, beforeEach, afterEach } from "node:test"
 import assert from "node:assert/strict"
-import path from "node:path"
 import fs from "node:fs/promises"
+import path from "node:path"
+import {afterEach,beforeEach,describe,it} from "node:test"
 
-import { FileObject, DirectoryObject, Sass } from "../../src/index.js"
-import { TestUtils } from "../helpers/test-utils.js"
+import {DirectoryObject,FileObject,Sass} from "../../src/index.js"
+import {TestUtils} from "../helpers/test-utils.js"
 
 describe("FileObject", () => {
   let testDir
@@ -12,7 +12,7 @@ describe("FileObject", () => {
   describe("constructor and basic properties", () => {
     it("creates FileObject with absolute path", () => {
       const file = new FileObject("/home/user/test.txt")
-      
+
       assert.ok(file instanceof FileObject)
       assert.equal(typeof file.supplied, "string")
       assert.equal(typeof file.path, "string")
@@ -25,7 +25,7 @@ describe("FileObject", () => {
 
     it("creates FileObject with relative path", () => {
       const file = new FileObject("../test.js")
-      
+
       assert.ok(path.isAbsolute(file.path))
       assert.equal(file.supplied, "../test.js")
       assert.equal(file.name, "test.js")
@@ -35,7 +35,7 @@ describe("FileObject", () => {
 
     it("creates FileObject with directory parameter as string", () => {
       const file = new FileObject("test.txt", "/home/user")
-      
+
       assert.ok(file.path.includes("/home/user"))
       assert.equal(file.name, "test.txt")
       assert.ok(file.directory instanceof DirectoryObject)
@@ -44,7 +44,7 @@ describe("FileObject", () => {
     it("creates FileObject with directory parameter as DirectoryObject", () => {
       const dir = new DirectoryObject("/home/user")
       const file = new FileObject("test.txt", dir)
-      
+
       assert.ok(file.path.includes("/home/user"))
       assert.equal(file.name, "test.txt")
       assert.ok(file.directory instanceof DirectoryObject)
@@ -52,7 +52,7 @@ describe("FileObject", () => {
 
     it("handles file without extension", () => {
       const file = new FileObject("/home/user/README")
-      
+
       assert.equal(file.name, "README")
       assert.equal(file.extension, "")
       assert.equal(file.module, "README")
@@ -60,7 +60,7 @@ describe("FileObject", () => {
 
     it("handles complex file extensions", () => {
       const file = new FileObject("/home/user/archive.tar.gz")
-      
+
       assert.equal(file.name, "archive.tar.gz")
       assert.equal(file.extension, ".gz")  // path.parse only gets last extension
       assert.equal(file.module, "archive.tar")
@@ -68,7 +68,7 @@ describe("FileObject", () => {
 
     it("fixes slashes in paths", () => {
       const file = new FileObject("path\\\\with\\\\backslashes\\\\file.txt")
-      
+
       assert.ok(!file.supplied.includes("\\\\"))
       assert.ok(file.supplied.includes("/"))
     })
@@ -124,7 +124,7 @@ describe("FileObject", () => {
     it("toString returns formatted string", () => {
       const file = new FileObject("/test/path/file.txt")
       const str = file.toString()
-      
+
       assert.ok(str.includes("FileObject"))
       assert.ok(str.includes(file.path))
     })
@@ -132,7 +132,7 @@ describe("FileObject", () => {
     it("toJSON returns object representation", () => {
       const file = new FileObject("/test/path/file.txt")
       const json = file.toJSON()
-      
+
       assert.equal(typeof json, "object")
       assert.ok("supplied" in json)
       assert.ok("path" in json)
@@ -143,7 +143,7 @@ describe("FileObject", () => {
       assert.ok("isFile" in json)
       assert.ok("isDirectory" in json)
       assert.ok("directory" in json)
-      
+
       assert.equal(json.isFile, true)
       assert.equal(json.isDirectory, false)
     })
@@ -156,7 +156,7 @@ describe("FileObject", () => {
       testDir = await TestUtils.createTestDir("file-obj-test")
       testFilePath = path.join(testDir, "test.txt")
       await fs.writeFile(testFilePath, "test content")
-      
+
       existingFile = new FileObject(testFilePath)
       nonExistentFile = new FileObject(path.join(testDir, "nonexistent.txt"))
     })
@@ -241,31 +241,31 @@ describe("FileObject", () => {
 
     it("write creates file with content", async () => {
       await testFile.write("Hello, world!")
-      
+
       const exists = await testFile.exists
       assert.equal(exists, true)
-      
+
       const content = await fs.readFile(testFilePath, "utf8")
       assert.equal(content, "Hello, world!")
     })
 
     it("read returns file content", async () => {
       await fs.writeFile(testFilePath, "test content")
-      
+
       const content = await testFile.read()
       assert.equal(content, "test content")
     })
 
     it("read with custom encoding", async () => {
       await fs.writeFile(testFilePath, "test content", "utf8")
-      
+
       const content = await testFile.read("utf8")
       assert.equal(content, "test content")
     })
 
     it("read throws for non-existent file", async () => {
       const nonExistentFile = new FileObject(path.join(testDir, "missing.txt"))
-      
+
       await assert.rejects(
         () => nonExistentFile.read(),
         Sass
@@ -274,7 +274,7 @@ describe("FileObject", () => {
 
     it("write with custom encoding", async () => {
       await testFile.write("test content", "utf8")
-      
+
       const content = await fs.readFile(testFilePath, "utf8")
       assert.equal(content, "test content")
     })
@@ -285,17 +285,17 @@ describe("FileObject", () => {
 
     beforeEach(async () => {
       testDir = await TestUtils.createTestDir("file-data-test")
-      
+
       // Create JSON file
       const jsonPath = path.join(testDir, "test.json")
       await fs.writeFile(jsonPath, JSON.stringify({ name: "test", value: 42 }))
       jsonFile = new FileObject(jsonPath)
-      
+
       // Create YAML file
       const yamlPath = path.join(testDir, "test.yaml")
       await fs.writeFile(yamlPath, "name: test\nvalue: 42\n")
       yamlFile = new FileObject(yamlPath)
-      
+
       // Create invalid file
       const invalidPath = path.join(testDir, "invalid.txt")
       await fs.writeFile(invalidPath, "this is not json or yaml")
@@ -310,7 +310,7 @@ describe("FileObject", () => {
 
     it("loads JSON data", async () => {
       const data = await jsonFile.loadData("json")
-      
+
       assert.equal(typeof data, "object")
       assert.equal(data.name, "test")
       assert.equal(data.value, 42)
@@ -318,7 +318,7 @@ describe("FileObject", () => {
 
     it("loads YAML data", async () => {
       const data = await yamlFile.loadData("yaml")
-      
+
       assert.equal(typeof data, "object")
       assert.equal(data.name, "test")
       assert.equal(data.value, 42)
@@ -327,7 +327,7 @@ describe("FileObject", () => {
     it("loads data with 'any' type (auto-detect)", async () => {
       const jsonData = await jsonFile.loadData("any")
       const yamlData = await yamlFile.loadData("any")
-      
+
       assert.equal(jsonData.name, "test")
       assert.equal(yamlData.name, "test")
     })
@@ -350,7 +350,7 @@ describe("FileObject", () => {
   describe("edge cases and error handling", () => {
     it("handles special characters in filename", () => {
       const file = new FileObject("/test/file with spaces & symbols!.txt")
-      
+
       assert.ok(file.name.includes("spaces"))
       assert.ok(file.name.includes("symbols"))
     })
@@ -358,13 +358,13 @@ describe("FileObject", () => {
     it("handles very long paths", () => {
       const longPath = "/test/" + "a".repeat(200) + "/file.txt"
       const file = new FileObject(longPath)
-      
+
       assert.ok(file.path.includes("a".repeat(200)))
     })
 
     it("meta object is frozen", () => {
       const file = new FileObject("/test/file.txt")
-      
+
       // Should not be able to modify internal meta
       assert.throws(() => {
         file.supplied = "modified"  // This should fail
@@ -375,7 +375,7 @@ describe("FileObject", () => {
       assert.throws(() => {
         new FileObject("")  // Empty filename
       }, Sass)
-      
+
       assert.throws(() => {
         new FileObject(null)  // Null filename
       }, Sass)
@@ -383,23 +383,23 @@ describe("FileObject", () => {
 
     it("resolves relative paths to absolute paths", () => {
       const file = new FileObject("tests/fixtures/settings.json")
-      
+
       // Path should be absolute
-      assert.ok(path.isAbsolute(file.path), 
+      assert.ok(path.isAbsolute(file.path),
         `Expected absolute path, got: ${file.path}`)
-      
+
       // Should start with root directory
-      assert.ok(file.path.startsWith('/'), 
+      assert.ok(file.path.startsWith('/'),
         `Path should start with /, got: ${file.path}`)
     })
 
     it("resolves relative paths with ./ prefix correctly", () => {
       const file = new FileObject("./tests/fixtures/settings.json")
-      
+
       // Path should be absolute
       assert.ok(path.isAbsolute(file.path),
         `Expected absolute path, got: ${file.path}`)
-      
+
       // Should not have duplicated path segments
       assert.ok(!file.path.includes('tests/fixtures/tests/fixtures'),
         `Path has duplicate segments: ${file.path}`)
@@ -408,15 +408,15 @@ describe("FileObject", () => {
     it("handles directory parameter correctly", () => {
       const file1 = new FileObject('settings.json', 'tests/fixtures')
       const file2 = new FileObject('settings.json', path.join(process.cwd(), 'tests/fixtures'))
-      
+
       // Both should resolve to absolute paths
       assert.ok(path.isAbsolute(file1.path))
       assert.ok(path.isAbsolute(file2.path))
-      
+
       // Should end with the same filename
       assert.ok(file1.path.endsWith('settings.json'))
       assert.ok(file2.path.endsWith('settings.json'))
-      
+
       // Should contain fixtures in the path
       assert.ok(file1.path.includes('fixtures'))
       assert.ok(file2.path.includes('fixtures'))
@@ -425,11 +425,11 @@ describe("FileObject", () => {
     it("preserves supplied path exactly as provided", () => {
       const testCases = [
         'simple.json',
-        './relative.json', 
+        './relative.json',
         'nested/path/file.json',
         '../parent.json'
       ]
-      
+
       testCases.forEach(inputPath => {
         const file = new FileObject(inputPath)
         assert.equal(file.supplied, inputPath,
@@ -440,7 +440,7 @@ describe("FileObject", () => {
     it("resolves absolute paths unchanged", () => {
       const absolutePath = path.join(process.cwd(), 'test.json')
       const file = new FileObject(absolutePath)
-      
+
       assert.equal(file.path, absolutePath)
       assert.ok(path.isAbsolute(file.path))
     })

--- a/tests/unit/Glog.test.js
+++ b/tests/unit/Glog.test.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 
-import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import console from 'node:console'
+import {afterEach,beforeEach,describe,it} from 'node:test'
 
 import Glog from '../../src/lib/Glog.js'
 
@@ -17,7 +17,7 @@ describe('Glog', () => {
     console.log = (...args) => {
       consoleOutput.push(args)
     }
-    
+
     // Reset Glog state
     Glog.setLogLevel(0).setLogPrefix('')
   })
@@ -30,7 +30,7 @@ describe('Glog', () => {
   describe('proxy functionality', () => {
     it('can be called as a function', () => {
       Glog('test message')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['test message'])
     })
@@ -38,22 +38,22 @@ describe('Glog', () => {
     it('can be called with log level', () => {
       Glog.setLogLevel(1) // Allow level 1 messages
       Glog(1, 'level 1 message')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['level 1 message'])
     })
 
     it('can use static methods', () => {
       const result = Glog.setLogLevel(2)
-      
+
       assert.equal(result, Glog) // Should return Glog for chaining
     })
 
     it('supports method chaining', () => {
       const result = Glog.setLogLevel(3).setLogPrefix('[TEST]')
-      
+
       assert.equal(result, Glog)
-      
+
       // Test that both settings were applied
       Glog(2, 'test message')
       assert.equal(consoleOutput.length, 1)
@@ -64,12 +64,12 @@ describe('Glog', () => {
   describe('log level filtering', () => {
     it('shows messages at or below log level', () => {
       Glog.setLogLevel(2)
-      
+
       Glog(0, 'level 0') // Should show
-      Glog(1, 'level 1') // Should show  
+      Glog(1, 'level 1') // Should show
       Glog(2, 'level 2') // Should show
       Glog(3, 'level 3') // Should NOT show
-      
+
       assert.equal(consoleOutput.length, 3)
       assert.deepEqual(consoleOutput[0], ['level 0'])
       assert.deepEqual(consoleOutput[1], ['level 1'])
@@ -78,10 +78,10 @@ describe('Glog', () => {
 
     it('defaults to level 0 when no level specified', () => {
       Glog.setLogLevel(0) // Only show level 0
-      
+
       Glog('no level specified') // Should show (defaults to 0)
       Glog(1, 'level 1')          // Should NOT show
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['no level specified'])
     })
@@ -101,27 +101,27 @@ describe('Glog', () => {
   describe('prefix handling', () => {
     it('adds prefix to all messages', () => {
       Glog.setLogPrefix('[APP]')
-      
+
       Glog('test message')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['[APP]', 'test message'])
     })
 
     it('works with multiple arguments', () => {
       Glog.setLogPrefix('[DEBUG]').setLogLevel(1) // Allow level 1 messages
-      
+
       Glog(1, 'user:', 'john', 'action:', 'login')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['[DEBUG]', 'user:', 'john', 'action:', 'login'])
     })
 
     it('handles empty prefix', () => {
       Glog.setLogPrefix('')
-      
+
       Glog('no prefix')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['no prefix'])
     })
@@ -129,10 +129,10 @@ describe('Glog', () => {
     it('can change prefix multiple times', () => {
       Glog.setLogPrefix('[FIRST]')
       Glog('first message')
-      
-      Glog.setLogPrefix('[SECOND]')  
+
+      Glog.setLogPrefix('[SECOND]')
       Glog('second message')
-      
+
       assert.equal(consoleOutput.length, 2)
       assert.deepEqual(consoleOutput[0], ['[FIRST]', 'first message'])
       assert.deepEqual(consoleOutput[1], ['[SECOND]', 'second message'])
@@ -154,7 +154,7 @@ describe('Glog', () => {
 
     it('handles single argument (message only)', () => {
       Glog('single argument')
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['single argument'])
     })
@@ -162,7 +162,7 @@ describe('Glog', () => {
     it('handles multiple message arguments', () => {
       Glog.setLogLevel(1) // Allow level 1 messages
       Glog(1, 'arg1', 'arg2', 'arg3', { key: 'value' })
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['arg1', 'arg2', 'arg3', { key: 'value' }])
     })
@@ -170,7 +170,7 @@ describe('Glog', () => {
     it('handles non-numeric first argument', () => {
       // Should treat 'not-a-number' as level 0 and message
       Glog('not-a-number', 'actual message')
-      
+
       assert.equal(consoleOutput.length, 1)
       // This behavior might be unexpected - check what actually happens
     })
@@ -179,11 +179,11 @@ describe('Glog', () => {
   describe('state management', () => {
     it('maintains state across multiple calls', () => {
       Glog.setLogLevel(1).setLogPrefix('[PERSIST]')
-      
+
       Glog(0, 'first call')
-      Glog(1, 'second call') 
+      Glog(1, 'second call')
       Glog(2, 'third call - should not show')
-      
+
       assert.equal(consoleOutput.length, 2)
       assert.deepEqual(consoleOutput[0], ['[PERSIST]', 'first call'])
       assert.deepEqual(consoleOutput[1], ['[PERSIST]', 'second call'])
@@ -191,11 +191,11 @@ describe('Glog', () => {
 
     it('state persists between function and static method calls', () => {
       Glog.setLogLevel(1)
-      
+
       Glog(0, 'function call') // Should show
-      Glog(1, 'second call') // Should show  
+      Glog(1, 'second call') // Should show
       Glog(2, 'filtered') // Should NOT show
-      
+
       assert.equal(consoleOutput.length, 2)
     })
   })
@@ -212,13 +212,13 @@ describe('Glog', () => {
     it('supports typical application logging', () => {
       // Setup like a real app might do
       Glog.setLogLevel(3).setLogPrefix('[MyApp]')
-      
+
       Glog(0, 'Application started')
       Glog(1, 'Warning: deprecated API used')
       Glog(2, 'User logged in:', 'user123')
       Glog(3, 'Debug: cache hit for key:', 'session:abc123')
       Glog(4, 'Verbose: memory usage', '45MB') // Should NOT show
-      
+
       assert.equal(consoleOutput.length, 4)
       assert.ok(consoleOutput.every(output => output[0] === '[MyApp]'))
     })
@@ -226,9 +226,9 @@ describe('Glog', () => {
     it('handles object and complex data logging', () => {
       const user = { id: 123, name: 'John' }
       const error = new Error('Something went wrong')
-      
+
       Glog(0, 'User data:', user, 'Error:', error.message)
-      
+
       assert.equal(consoleOutput.length, 1)
       assert.deepEqual(consoleOutput[0], ['User data:', user, 'Error:', error.message])
     })

--- a/tests/unit/Sass.test.js
+++ b/tests/unit/Sass.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import {describe,it} from "node:test"
 
-import { Sass } from "../../src/index.js"
+import {Sass} from "../../src/index.js"
 
 // Helpers for intercepting console output
 /**

--- a/tests/unit/Term.test.js
+++ b/tests/unit/Term.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import {describe,it} from "node:test"
 
-import { Term, Sass } from "../../src/index.js"
+import {Sass, Term} from "../../src/index.js"
 
 /**
  * Helper to capture console output for testing
@@ -72,19 +72,19 @@ describe("Term", () => {
   describe("terminalBracket", () => {
     it("creates basic bracketed text", () => {
       const result = Term.terminalBracket(["success", "COMPILED"])
-      
+
       assert.equal(result, "[COMPILED]")
     })
 
     it("uses custom brackets when provided", () => {
       const result = Term.terminalBracket(["info", "STATUS", ["<", ">"]])
-      
+
       assert.equal(result, "<STATUS>")
     })
 
     it("defaults to square brackets", () => {
       const result = Term.terminalBracket(["error", "FAILED"])
-      
+
       assert.equal(result, "[FAILED]")
     })
 
@@ -100,13 +100,13 @@ describe("Term", () => {
   describe("terminalMessage", () => {
     it("returns string input unchanged", () => {
       const result = Term.terminalMessage("simple message")
-      
+
       assert.equal(result, "simple message")
     })
 
     it("processes array with plain strings", () => {
       const result = Term.terminalMessage(["Hello", "world"])
-      
+
       assert.equal(result, "Hello world")
     })
 
@@ -116,7 +116,7 @@ describe("Term", () => {
         ["success", "OK"],
         "- processing complete"
       ])
-      
+
       assert.equal(result, "Status: [OK] - processing complete")
     })
 
@@ -126,7 +126,7 @@ describe("Term", () => {
         ["error", "FAILED", ["<", ">"]],
         "check logs"
       ])
-      
+
       assert.equal(result, "Alert: <FAILED> check logs")
     })
 
@@ -137,7 +137,7 @@ describe("Term", () => {
         "for project:",
         ["success", "MyApp"]
       ])
-      
+
       assert.equal(result, "Build [STARTED] for project: [MyApp]")
     })
 
@@ -198,7 +198,7 @@ describe("Term", () => {
 
     it("resetTerminal exists and returns a promise", async () => {
       assert.equal(typeof Term.resetTerminal, "function")
-      
+
       // resetTerminal may fail if stdin doesn't support setRawMode (like in test environment)
       try {
         const result = Term.resetTerminal()

--- a/tests/unit/TypeSpec.test.js
+++ b/tests/unit/TypeSpec.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import {describe,it} from "node:test"
 
-import { Type, Sass } from "../../src/index.js"
+import {Sass,Type} from "../../src/index.js"
 
 describe("Type", () => {
   describe("constructor and basic properties", () => {
@@ -54,7 +54,7 @@ describe("Type", () => {
       assert.throws(() => {
         spec.length = 99
       }, TypeError)
-      
+
       assert.throws(() => {
         spec.specs = []
       }, TypeError)
@@ -271,11 +271,11 @@ describe("Type", () => {
       assert.equal(spec.match("hello"), true)
       assert.equal(spec.match(true), true)
       assert.equal(spec.match([1, 2, 3]), true)
-      
+
       // Should NOT match array types not in union
       assert.equal(spec.match(["a", "b"]), false)
       assert.equal(spec.match([true, false]), false)
-      
+
       // Should handle mixed arrays correctly
       assert.equal(spec.match([1, "mixed"]), false)
     })
@@ -283,12 +283,12 @@ describe("Type", () => {
     it("respects allowEmpty for different value types", () => {
       const stringSpec = new Type("string")
       const arraySpec = new Type("string[]")
-      
+
       // String emptiness
       assert.equal(stringSpec.match("", { allowEmpty: true }), true)
       assert.equal(stringSpec.match("", { allowEmpty: false }), false)
       assert.equal(stringSpec.match("  ", { allowEmpty: false }), false) // whitespace-only is empty
-      
+
       // Array emptiness
       assert.equal(arraySpec.match([], { allowEmpty: true }), true)
       assert.equal(arraySpec.match([], { allowEmpty: false }), false)

--- a/tests/unit/Util.test.js
+++ b/tests/unit/Util.test.js
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
-import { EventEmitter } from "node:events"
+import {EventEmitter} from "node:events"
+import {describe, it} from "node:test"
 
-import { Util, Sass } from "../../src/index.js"
+import {Sass,Util} from "../../src/index.js"
 
 
 describe("Util", () => {
@@ -33,7 +33,7 @@ describe("Util", () => {
       assert.equal(Util.capitalize(undefined), undefined) // Returns undefined unchanged!
       assert.equal(Util.capitalize(123), 123) // Returns number unchanged!
       assert.deepEqual(Util.capitalize([1, 2, 3]), [1, 2, 3]) // Returns array unchanged!
-      
+
       // This is problematic - should these be errors instead?
     })
 
@@ -101,7 +101,7 @@ describe("Util", () => {
   describe("rightAlignText()", () => {
     it("right-aligns text within default width (80)", () => {
       const result = Util.rightAlignText("hello")
-      
+
       assert.equal(result.length, 80)
       assert.ok(result.endsWith("hello"))
       assert.ok(result.startsWith("     ")) // Should start with spaces
@@ -109,14 +109,14 @@ describe("Util", () => {
 
     it("right-aligns with custom width", () => {
       const result = Util.rightAlignText("test", 10)
-      
+
       assert.equal(result.length, 10)
       assert.equal(result, "      test")
     })
 
     it("handles numbers by converting to strings", () => {
       const result = Util.rightAlignText(123, 10)
-      
+
       assert.equal(result.length, 10)
       assert.equal(result, "       123")
     })
@@ -124,7 +124,7 @@ describe("Util", () => {
     it("returns unchanged if text exceeds width", () => {
       const longText = "This text is definitely longer than 10 characters"
       const result = Util.rightAlignText(longText, 10)
-      
+
       assert.equal(result, longText) // Should return unchanged
       assert.ok(result.length > 10)
     })
@@ -132,10 +132,10 @@ describe("Util", () => {
     it("handles edge cases", () => {
       // Zero width
       assert.equal(Util.rightAlignText("test", 0), "test")
-      
-      // Negative width  
+
+      // Negative width
       assert.equal(Util.rightAlignText("test", -5), "test")
-      
+
       // Exact width match
       assert.equal(Util.rightAlignText("1234567890", 10), "1234567890")
     })
@@ -151,7 +151,7 @@ describe("Util", () => {
     it("generates consistent SHA256 hashes", () => {
       const hash1 = Util.hashOf("hello world")
       const hash2 = Util.hashOf("hello world")
-      
+
       assert.equal(hash1, hash2) // Should be deterministic
       assert.equal(hash1.length, 64) // SHA256 is 64 hex chars
       assert.match(hash1, /^[a-f0-9]{64}$/) // Should be valid hex
@@ -160,13 +160,13 @@ describe("Util", () => {
     it("generates different hashes for different inputs", () => {
       const hash1 = Util.hashOf("hello")
       const hash2 = Util.hashOf("world")
-      
+
       assert.notEqual(hash1, hash2)
     })
 
     it("handles empty strings", () => {
       const hash = Util.hashOf("")
-      
+
       assert.equal(hash.length, 64)
       assert.match(hash, /^[a-f0-9]{64}$/)
       // SHA256 of empty string is known value
@@ -176,7 +176,7 @@ describe("Util", () => {
     it("handles unicode and special characters", () => {
       const hash1 = Util.hashOf("🚀 rocket")
       const hash2 = Util.hashOf("émilie café")
-      
+
       assert.equal(hash1.length, 64)
       assert.equal(hash2.length, 64)
       assert.notEqual(hash1, hash2)
@@ -199,10 +199,10 @@ describe("Util", () => {
     it("extracts long option names", () => {
       const options = {
         "-w, --watch": "Watch for changes",
-        "-b, --build": "Build the project", 
+        "-b, --build": "Build the project",
         "--config": "Config file path"
       }
-      
+
       const names = Util.generateOptionNames(options)
       assert.deepEqual(names.sort(), ["build", "config", "watch"])
     })
@@ -212,7 +212,7 @@ describe("Util", () => {
         "-v, --verbose": "Verbose output",
         "-q, --quiet": "Quiet mode"
       }
-      
+
       const names = Util.generateOptionNames(options)
       assert.deepEqual(names.sort(), ["quiet", "verbose"])
       // Should not include "v" or "q"
@@ -224,7 +224,7 @@ describe("Util", () => {
         "-h": "Help",
         "--config": "Config file"
       }
-      
+
       const names = Util.generateOptionNames(options)
       assert.deepEqual(names.sort(), ["config", "h", "v"])
     })
@@ -237,7 +237,7 @@ describe("Util", () => {
         "--": "Just double dash",
         "-w, --watch": "Valid option"
       }
-      
+
       const names = Util.generateOptionNames(options)
       // Should filter out malformed options and only return valid ones
       // After fix: empty option names like "-" should be filtered out
@@ -250,7 +250,7 @@ describe("Util", () => {
         "  -v  ,  --verbose  ": "Spaces around options",
         "-f,--file": "No space after comma"
       }
-      
+
       const names = Util.generateOptionNames(options)
       assert.deepEqual(names.sort(), ["file", "verbose", "watch"])
     })
@@ -265,11 +265,11 @@ describe("Util", () => {
       const options = {
         "-123": "Numeric option",
         "--multi-word-option": "Multi word",
-        "-_": "Underscore option", 
+        "-_": "Underscore option",
         "--": "Empty long option",
         "not-an-option": "No dashes"
       }
-      
+
       const names = Util.generateOptionNames(options)
       // Let's see what gets through the filter
       console.log("Edge case results:", names)
@@ -284,7 +284,7 @@ describe("Util", () => {
           Promise.resolve(2),
           Promise.resolve(3)
         ]
-        
+
         const results = await Util.awaitAll(promises)
         assert.deepEqual(results, [1, 2, 3])
       })
@@ -295,7 +295,7 @@ describe("Util", () => {
           Promise.reject(new Error("Test error")),
           Promise.resolve(3)
         ]
-        
+
         await assert.rejects(
           () => Util.awaitAll(promises),
           /Test error/
@@ -315,9 +315,9 @@ describe("Util", () => {
           Promise.reject(new Error("failure")),
           Promise.resolve(42)
         ]
-        
+
         const results = await Util.settleAll(promises)
-        
+
         assert.equal(results.length, 3)
         assert.equal(results[0].status, "fulfilled")
         assert.equal(results[0].value, "success")
@@ -335,7 +335,7 @@ describe("Util", () => {
           Promise.resolve("fast"),
           new Promise(resolve => setTimeout(() => resolve("medium"), 50))
         ]
-        
+
         const result = await Util.race(promises)
         assert.equal(result, "fast")
       })
@@ -346,7 +346,7 @@ describe("Util", () => {
           Promise.reject(new Error("fast error")),
           Promise.resolve("success")
         ]
-        
+
         await assert.rejects(
           () => Util.race(promises),
           /fast error/
@@ -368,13 +368,13 @@ describe("Util", () => {
         })
 
         emitter.on("test", async () => {
-          executionOrder.push("listener2-start") 
+          executionOrder.push("listener2-start")
           await new Promise(resolve => setTimeout(resolve, 25))
           executionOrder.push("listener2-end")
         })
 
         await Util.asyncEmit(emitter, "test", "payload")
-        
+
         // All listeners should have completed
         assert.ok(executionOrder.includes("listener1-end"))
         assert.ok(executionOrder.includes("listener2-end"))
@@ -412,7 +412,7 @@ describe("Util", () => {
 
       it("handles events with no listeners", async () => {
         const emitter = new EventEmitter()
-        
+
         // Should not throw for events with no listeners
         await Util.asyncEmit(emitter, "nonexistent")
       })
@@ -426,7 +426,7 @@ describe("Util", () => {
         })
 
         await Util.asyncEmit(emitter, "test", "arg1", 42, {key: "value"})
-        
+
         assert.deepEqual(receivedArgs, ["arg1", 42, {key: "value"}])
       })
     })

--- a/tests/unit/Valid.test.js
+++ b/tests/unit/Valid.test.js
@@ -1,7 +1,7 @@
-import { describe, it } from "node:test"
 import assert from "node:assert/strict"
+import {describe,it} from "node:test"
 
-import { Valid, Sass } from "../../src/index.js"
+import {Sass,Valid} from "../../src/index.js"
 
 describe("Valid", () => {
   describe("assert", () => {
@@ -42,7 +42,7 @@ describe("Valid", () => {
       }, /Condition must be a boolean/)
 
       assert.throws(() => {
-        Valid.assert(123, "message") 
+        Valid.assert(123, "message")
       }, /Condition must be a boolean/)
 
       assert.throws(() => {
@@ -94,15 +94,15 @@ describe("Valid", () => {
       assert.throws(() => {
         Valid.validType(123, "string")
       }, (error) => {
-        return error instanceof Sass && 
+        return error instanceof Sass &&
                error.message.includes("Invalid type") &&
                error.message.includes("Expected string")
       })
 
       assert.throws(() => {
-        Valid.validType("hello", "number") 
+        Valid.validType("hello", "number")
       }, (error) => {
-        return error instanceof Sass && 
+        return error instanceof Sass &&
                error.message.includes("Invalid type") &&
                error.message.includes("Expected number")
       })
@@ -130,7 +130,7 @@ describe("Valid", () => {
     it("passes options to underlying type checking", () => {
       // Test with allowEmpty option
       Valid.validType("", "string", { allowEmpty: true }) // Should not throw
-      
+
       assert.throws(() => {
         Valid.validType("", "string", { allowEmpty: false })
       }, Sass)
@@ -140,7 +140,7 @@ describe("Valid", () => {
       assert.throws(() => {
         Valid.validType([1, "mixed"], "number[]")
       }, (error) => {
-        return error instanceof Sass && 
+        return error instanceof Sass &&
                error.message.includes("Invalid type") &&
                error.message.includes("Expected number[]")
       })
@@ -151,7 +151,7 @@ describe("Valid", () => {
     it("handles null and undefined in assert", () => {
       Valid.assert(true, "message", null)
       Valid.assert(true, "message", undefined)
-      
+
       assert.throws(() => {
         Valid.assert(false, "message", null)
       }, (error) => {


### PR DESCRIPTION
# Move fdType, upperFdTypes, and fdTypes to static properties on FS class

This PR refactors the file descriptor type constants by moving them from module-level exports to static properties on the FS class. This change improves encapsulation and provides a more consistent API.

Key changes:
- Moved `fdType`, `upperFdTypes`, and `fdTypes` to be static properties on the FS class
- Updated TypeScript type definitions to reflect this change
- Updated exports in index.js to only export the FS class
- Bumped package version from 0.1.1 to 0.1.2
- Fixed import formatting in test files for consistency

To access these constants, use `FS.fdType`, `FS.upperFdTypes`, and `FS.fdTypes` instead of importing them directly.