### PR TITLE
Remove directory parameter from DirectoryObject.read() and bump version to 0.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# npm i @gesslar/toolkit
+# `npm i @gesslar/toolkit`
 
 This package is intended to be a collection of useful utilities for any
 project's consumption. Not the kind that gives you bleeding, hacking coughs,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/DirectoryObject.js
+++ b/src/lib/DirectoryObject.js
@@ -209,18 +209,17 @@ export default class DirectoryObject extends FS {
   /**
    * Lists the contents of a directory.
    *
-   * @param {DirectoryObject} directory - The directory to list.
    * @returns {Promise<{files: Array<FileObject>, directories: Array<DirectoryObject>}>} The files and directories in the directory.
    */
-  async read(directory) {
+  async read() {
     const found = await fs.readdir(
-      new URL(directory.uri),
+      new URL(this.uri),
       {withFileTypes: true}
     )
 
     const results = await Promise.all(
       found.map(async dirent => {
-        const fullPath = path.join(directory.path, dirent.name)
+        const fullPath = path.join(this.path, dirent.name)
         const stat = await fs.stat(fullPath)
 
         return {dirent, stat, fullPath}

--- a/tests/unit/DirectoryObject.test.js
+++ b/tests/unit/DirectoryObject.test.js
@@ -172,7 +172,7 @@ describe("DirectoryObject", () => {
     })
 
     it("returns files and directories", async () => {
-      const result = await testDirObj.read(testDirObj)
+      const result = await testDirObj.read()
 
       assert.ok(Array.isArray(result.files))
       assert.ok(Array.isArray(result.directories))
@@ -181,14 +181,14 @@ describe("DirectoryObject", () => {
     })
 
     it("returned files are FileObject instances", async () => {
-      const { files } = await testDirObj.read(testDirObj)
+      const { files } = await testDirObj.read()
 
       // Note: This might fail due to circular import
       assert.ok(files[0].constructor.name === "FileObject")
     })
 
     it("returned directories are DirectoryObject instances", async () => {
-      const { directories } = await testDirObj.read(testDirObj)
+      const { directories } = await testDirObj.read()
 
       assert.ok(directories[0] instanceof DirectoryObject)
     })
@@ -198,7 +198,7 @@ describe("DirectoryObject", () => {
       await fs.mkdir(emptyDir)
       const emptyDirObj = new DirectoryObject(emptyDir)
 
-      const result = await emptyDirObj.read(emptyDirObj)
+      const result = await emptyDirObj.read()
       assert.equal(result.files.length, 0)
       assert.equal(result.directories.length, 0)
     })


### PR DESCRIPTION
# Simplify DirectoryObject.read() method signature

This PR removes the unnecessary `directory` parameter from the `DirectoryObject.read()` method, as the method can simply use `this` to reference the current directory object. The method now operates on the instance it's called on rather than requiring a directory to be passed in.

All test cases have been updated to use the new method signature. Version bumped to 0.1.3.