### PR TITLE
Rename Valid.validType to Valid.type and bump version to 0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/Data.js
+++ b/src/lib/Data.js
@@ -273,9 +273,9 @@ export default class Data {
    * @returns {Promise<object>} The mapped object
    */
   static async mapObject(original, transformer, mutate = false) {
-    Valid.validType(original, "object", {allowEmpty: true})
-    Valid.validType(transformer, "function")
-    Valid.validType(mutate, "boolean")
+    Valid.type(original, "object", {allowEmpty: true})
+    Valid.type(transformer, "function")
+    Valid.type(mutate, "boolean")
 
     const result = mutate ? original : {}
 

--- a/src/lib/Valid.js
+++ b/src/lib/Valid.js
@@ -5,14 +5,13 @@ import Data from "./Data.js"
 
 export default class Valid {
 /**
- * Validates a value against a type
+ * Validates a value against a type. Uses Data.isType.
  *
  * @param {unknown} value - The value to validate
- * @param {string} type - The expected type in the form of "object",
- *                        "object[]", "object|object[]"
+ * @param {string} type - The expected type in the form of "object", "object[]", "object|object[]"
  * @param {object} [options] - Additional options for validation.
  */
-  static validType(value, type, options) {
+  static type(value, type, options) {
     Valid.assert(
       Data.isType(value, type, options),
       `Invalid type. Expected ${type}, got ${JSON.stringify(value)}`,

--- a/src/types/Valid.d.ts
+++ b/src/types/Valid.d.ts
@@ -3,7 +3,7 @@
 
 export default class Valid {
   /** Validate a value against a type specification */
-  static validType(value: unknown, type: string, options?: { allowEmpty?: boolean }): void
+  static type(value: unknown, type: string, options?: { allowEmpty?: boolean }): void
 
   /** Assert a condition */
   static assert(condition: boolean, message: string, arg?: number | null): void

--- a/tests/unit/Valid.test.js
+++ b/tests/unit/Valid.test.js
@@ -79,20 +79,20 @@ describe("Valid", () => {
     })
   })
 
-  describe("validType", () => {
+  describe("type", () => {
     it("passes for valid basic types", () => {
       // These should not throw
-      Valid.validType("hello", "string")
-      Valid.validType(123, "number")
-      Valid.validType(true, "boolean")
-      Valid.validType([], "array")
-      Valid.validType({}, "object")
-      Valid.validType(() => {}, "function")
+      Valid.type("hello", "string")
+      Valid.type(123, "number")
+      Valid.type(true, "boolean")
+      Valid.type([], "array")
+      Valid.type({}, "object")
+      Valid.type(() => {}, "function")
     })
 
     it("throws Sass error for invalid types", () => {
       assert.throws(() => {
-        Valid.validType(123, "string")
+        Valid.type(123, "string")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
@@ -100,7 +100,7 @@ describe("Valid", () => {
       })
 
       assert.throws(() => {
-        Valid.validType("hello", "number")
+        Valid.type("hello", "number")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
@@ -110,35 +110,35 @@ describe("Valid", () => {
 
     it("works with type specifications", () => {
       // Array types
-      Valid.validType([1, 2, 3], "number[]") // Should not throw
-      Valid.validType(["a", "b"], "string[]") // Should not throw
+      Valid.type([1, 2, 3], "number[]") // Should not throw
+      Valid.type(["a", "b"], "string[]") // Should not throw
 
       assert.throws(() => {
-        Valid.validType([1, "mixed"], "number[]")
+        Valid.type([1, "mixed"], "number[]")
       }, Sass)
     })
 
     it("works with union types", () => {
-      Valid.validType("hello", "string|number") // Should not throw
-      Valid.validType(123, "string|number") // Should not throw
+      Valid.type("hello", "string|number") // Should not throw
+      Valid.type(123, "string|number") // Should not throw
 
       assert.throws(() => {
-        Valid.validType(true, "string|number")
+        Valid.type(true, "string|number")
       }, Sass)
     })
 
     it("passes options to underlying type checking", () => {
       // Test with allowEmpty option
-      Valid.validType("", "string", { allowEmpty: true }) // Should not throw
+      Valid.type("", "string", { allowEmpty: true }) // Should not throw
 
       assert.throws(() => {
-        Valid.validType("", "string", { allowEmpty: false })
+        Valid.type("", "string", { allowEmpty: false })
       }, Sass)
     })
 
     it("provides detailed error messages", () => {
       assert.throws(() => {
-        Valid.validType([1, "mixed"], "number[]")
+        Valid.type([1, "mixed"], "number[]")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
@@ -168,9 +168,9 @@ describe("Valid", () => {
         }
       }
 
-      Valid.validType(complexObject, "object") // Should not throw
-      Valid.validType(complexObject.values, "number[]") // Should not throw
-      Valid.validType(complexObject.nested.flag, "boolean") // Should not throw
+      Valid.type(complexObject, "object") // Should not throw
+      Valid.type(complexObject.values, "number[]") // Should not throw
+      Valid.type(complexObject.nested.flag, "boolean") // Should not throw
     })
   })
 })


### PR DESCRIPTION
# Rename `validType` to `type` in Valid class

This PR renames the `validType` method to `type` in the `Valid` class for a more concise API. The change includes:

- Renaming the method in the `Valid` class implementation
- Updating the TypeScript type definitions
- Updating all internal calls to use the new method name
- Updating all test cases to use the new method name
- Bumping package version from 0.1.4 to 0.1.5

The functionality remains the same, but the API is now more streamlined.