### PR TITLE
Capitalize type names and improve type detection system, bump version to 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/TypeSpec.js
+++ b/src/lib/TypeSpec.js
@@ -6,6 +6,7 @@
 
 import Sass from "./Sass.js"
 import Data from "./Data.js"
+import Util from "./Util.js"
 
 /**
  * Type specification class for parsing and validating complex type definitions.
@@ -149,7 +150,7 @@ export default class TypeSpec {
     // Now, let's do some checking with the types, respecting the array flag
     // with the value
     const valueType = Data.typeOf(value)
-    const isArray = valueType === "array"
+    const isArray = valueType === "Array"
 
     // We need to ensure that we match the type and the consistency of the types
     // in an array, if it is an array and an array is allowed.
@@ -166,8 +167,8 @@ export default class TypeSpec {
 
       // Handle array values
       if(isArray) {
-        // Special case for generic "array" type
-        if(allowedType === "array" && !allowedArray)
+        // Special case for generic "Array" type
+        if(allowedType === "Array" && !allowedArray)
           return allowEmpty || !empty
 
         // Must be an array type specification
@@ -203,16 +204,18 @@ export default class TypeSpec {
     const parts = string.split(delimiter)
 
     this.#specs = parts.map(part => {
-      const typeMatches = /(\w+)(\[\])?/.exec(part)
+      const typeMatches = /^(\w+)(\[\])?$/.exec(part)
 
       if(!typeMatches || typeMatches.length !== 3)
         throw Sass.new(`Invalid type: ${part}`)
 
-      if(!Data.isValidType(typeMatches[1]))
+      const typeName = Util.capitalize(typeMatches[1])
+
+      if(!Data.isValidType(typeName))
         throw Sass.new(`Invalid type: ${typeMatches[1]}`)
 
       return {
-        typeName: typeMatches[1],
+        typeName,
         array: typeMatches[2] === "[]",
       }
     })

--- a/tests/unit/Data.test.js
+++ b/tests/unit/Data.test.js
@@ -6,7 +6,7 @@ import {Data,Sass,Type} from "../../src/index.js"
 describe("Data", () => {
   describe("static properties", () => {
     it("has correct primitive types", () => {
-      const expected = ["undefined", "null", "boolean", "number", "bigint", "string", "symbol", "object", "function"]
+      const expected = ["Undefined", "Null", "Boolean", "Number", "Bigint", "String", "Symbol", "Object", "Function"]
       assert.deepEqual(Data.primitives, expected)
       assert.ok(Object.isFrozen(Data.primitives))
     })
@@ -23,13 +23,13 @@ describe("Data", () => {
     it("combines primitives and constructors in dataTypes", () => {
       const expectedLength = Data.primitives.length + Data.constructors.length
       assert.equal(Data.dataTypes.length, expectedLength)
-      assert.ok(Data.dataTypes.includes("string"))
-      assert.ok(Data.dataTypes.includes("array"))
+      assert.ok(Data.dataTypes.includes("String"))
+      assert.ok(Data.dataTypes.includes("Array"))
       assert.ok(Object.isFrozen(Data.dataTypes))
     })
 
     it("has correct emptyable types", () => {
-      const expected = ["string", "array", "object"]
+      const expected = ["String", "Array", "Object"]
       assert.deepEqual(Data.emptyableTypes, expected)
       assert.ok(Object.isFrozen(Data.emptyableTypes))
     })
@@ -240,7 +240,7 @@ describe("Data", () => {
     it("newTypeSpec creates TypeSpec instances", () => {
       const spec = Data.newTypeSpec("string|number[]")
       assert.ok(spec instanceof Type)
-      assert.equal(spec.stringRepresentation, "string|number[]")
+      assert.equal(spec.stringRepresentation, "String|Number[]")
     })
 
     it("isType delegates to TypeSpec.match", () => {
@@ -251,26 +251,27 @@ describe("Data", () => {
     })
 
     it("isValidType checks against dataTypes list", () => {
-      assert.equal(Data.isValidType("string"), true)
-      assert.equal(Data.isValidType("array"), true)
+      assert.equal(Data.isValidType("String"), true)
+      assert.equal(Data.isValidType("Array"), true)
       assert.equal(Data.isValidType("invalidtype"), false)
       assert.equal(Data.isValidType(""), false)
     })
 
     it("isBaseType checks primitive/constructor types only", () => {
-      assert.equal(Data.isBaseType("hello", "string"), true)
-      assert.equal(Data.isBaseType([1, 2], "array"), true)
-      assert.equal(Data.isBaseType({}, "object"), true)
-      assert.equal(Data.isBaseType(null, "object"), false) // null excluded
-      assert.equal(Data.isBaseType(NaN, "number"), false) // NaN excluded
-      assert.equal(Data.isBaseType(null, "null"), true)
+      assert.equal(Data.isBaseType("hello", "String"), true)
+      assert.equal(Data.isBaseType([1, 2], "Array"), true)
+      assert.equal(Data.isBaseType({}, "Object"), true)
+      assert.equal(Data.isBaseType(null, "Object"), false) // null excluded
+      assert.equal(Data.isBaseType(NaN, "Number"), false) // NaN excluded
+      assert.equal(Data.isBaseType(null, "Null"), true)
     })
 
     it("typeOf returns enhanced typeof", () => {
-      assert.equal(Data.typeOf("hello"), "string")
-      assert.equal(Data.typeOf([]), "array") // enhanced for arrays
-      assert.equal(Data.typeOf({}), "object")
-      assert.equal(Data.typeOf(null), "null") // enhanced to distinguish null from object
+      assert.equal(Data.typeOf("hello"), "String")
+      assert.equal(Data.typeOf([]), "Array") // enhanced for arrays
+      assert.equal(Data.typeOf({}), "Object")
+      assert.equal(Data.typeOf(null), "Null") // enhanced to distinguish null from object
+      assert.equal(Data.typeOf(new RegExp), "RegExp") // enhanced to distinguish null from object
     })
   })
 
@@ -425,8 +426,8 @@ describe("Data", () => {
 
   describe("edge cases and error handling", () => {
     it("handles null/undefined inputs gracefully", () => {
-      assert.equal(Data.typeOf(null), "null")
-      assert.equal(Data.typeOf(undefined), "undefined")
+      assert.equal(Data.typeOf(null), "Null")
+      assert.equal(Data.typeOf(undefined), "Undefined")
       assert.equal(Data.deepFreezeObject(null), null)
       assert.equal(Data.deepFreezeObject("not object"), "not object")
     })

--- a/tests/unit/TypeSpec.test.js
+++ b/tests/unit/TypeSpec.test.js
@@ -9,9 +9,9 @@ describe("Type", () => {
       const spec = new Type("string")
 
       assert.equal(spec.length, 1)
-      assert.equal(spec.stringRepresentation, "string")
+      assert.equal(spec.stringRepresentation, "String")
       assert.ok(spec.specs)
-      assert.equal(spec.specs[0].typeName, "string")
+      assert.equal(spec.specs[0].typeName, "String")
       assert.equal(spec.specs[0].array, false)
     })
 
@@ -19,8 +19,8 @@ describe("Type", () => {
       const spec = new Type("number[]")
 
       assert.equal(spec.length, 1)
-      assert.equal(spec.stringRepresentation, "number[]")
-      assert.equal(spec.specs[0].typeName, "number")
+      assert.equal(spec.stringRepresentation, "Number[]")
+      assert.equal(spec.specs[0].typeName, "Number")
       assert.equal(spec.specs[0].array, true)
     })
 
@@ -28,10 +28,10 @@ describe("Type", () => {
       const spec = new Type("string|number")
 
       assert.equal(spec.length, 2)
-      assert.equal(spec.stringRepresentation, "string|number")
-      assert.equal(spec.specs[0].typeName, "string")
+      assert.equal(spec.stringRepresentation, "String|Number")
+      assert.equal(spec.specs[0].typeName, "String")
       assert.equal(spec.specs[0].array, false)
-      assert.equal(spec.specs[1].typeName, "number")
+      assert.equal(spec.specs[1].typeName, "Number")
       assert.equal(spec.specs[1].array, false)
     })
 
@@ -39,12 +39,12 @@ describe("Type", () => {
       const spec = new Type("string[]|number|boolean[]")
 
       assert.equal(spec.length, 3)
-      assert.equal(spec.stringRepresentation, "string[]|number|boolean[]")
-      assert.equal(spec.specs[0].typeName, "string")
+      assert.equal(spec.stringRepresentation, "String[]|Number|Boolean[]")
+      assert.equal(spec.specs[0].typeName, "String")
       assert.equal(spec.specs[0].array, true)
-      assert.equal(spec.specs[1].typeName, "number")
+      assert.equal(spec.specs[1].typeName, "Number")
       assert.equal(spec.specs[1].array, false)
-      assert.equal(spec.specs[2].typeName, "boolean")
+      assert.equal(spec.specs[2].typeName, "Boolean")
       assert.equal(spec.specs[2].array, true)
     })
 
@@ -64,9 +64,9 @@ describe("Type", () => {
   describe("validation methods", () => {
     it("throws for invalid type names", () => {
       assert.throws(() => {
-        new Type("invalidtype")
+        new Type("123invalid")
       }, (error) => {
-        return error instanceof Sass && error.message.includes("Invalid type: invalidtype")
+        return error instanceof Sass && error.message.includes("Invalid type: 123invalid")
       })
     })
 
@@ -89,7 +89,7 @@ describe("Type", () => {
 
       spec.forEach(s => types.push(s.typeName))
 
-      assert.deepEqual(types, ["string", "number"])
+      assert.deepEqual(types, ["String", "Number"])
     })
 
     it("every tests all specs", () => {
@@ -111,15 +111,15 @@ describe("Type", () => {
       const arrays = spec.filter(s => s.array)
 
       assert.equal(arrays.length, 2)
-      assert.equal(arrays[0].typeName, "string")
-      assert.equal(arrays[1].typeName, "boolean")
+      assert.equal(arrays[0].typeName, "String")
+      assert.equal(arrays[1].typeName, "Boolean")
     })
 
     it("map transforms specs", () => {
       const spec = new Type("string|number")
       const names = spec.map(s => s.typeName)
 
-      assert.deepEqual(names, ["string", "number"])
+      assert.deepEqual(names, ["String", "Number"])
     })
 
     it("reduce accumulates specs", () => {
@@ -130,18 +130,18 @@ describe("Type", () => {
     })
 
     it("find returns first matching spec", () => {
-      const spec = new Type("string[]|number|boolean[]")
-      const found = spec.find(s => s.array && s.typeName === "boolean")
+      const spec = new Type("String[]|Number|Boolean[]")
+      const found = spec.find(s => s.array && s.typeName === "Boolean")
 
       assert.ok(found)
-      assert.equal(found.typeName, "boolean")
+      assert.equal(found.typeName, "Boolean")
       assert.equal(found.array, true)
     })
   })
 
   describe("match method", () => {
     it("matches simple types", () => {
-      const spec = new Type("string")
+      const spec = new Type("String")
 
       assert.equal(spec.match("hello"), true)
       assert.equal(spec.match(123), false)
@@ -149,7 +149,7 @@ describe("Type", () => {
     })
 
     it("matches array types", () => {
-      const spec = new Type("string[]")
+      const spec = new Type("String[]")
 
       assert.equal(spec.match(["a", "b", "c"]), true)
       assert.equal(spec.match([1, 2, 3]), false)
@@ -157,7 +157,7 @@ describe("Type", () => {
     })
 
     it("matches union types", () => {
-      const spec = new Type("string|number")
+      const spec = new Type("String|Number")
 
       assert.equal(spec.match("hello"), true)
       assert.equal(spec.match(123), true)
@@ -165,7 +165,7 @@ describe("Type", () => {
     })
 
     it("matches mixed array and non-array types", () => {
-      const spec = new Type("string|number[]")
+      const spec = new Type("String|Number[]")
 
       assert.equal(spec.match("hello"), true)
       assert.equal(spec.match([1, 2, 3]), true)
@@ -174,21 +174,21 @@ describe("Type", () => {
     })
 
     it("handles empty arrays with allowEmpty option", () => {
-      const spec = new Type("string[]")
+      const spec = new Type("String[]")
 
       assert.equal(spec.match([], { allowEmpty: true }), true)
       assert.equal(spec.match([], { allowEmpty: false }), false)
     })
 
     it("handles empty strings with allowEmpty option", () => {
-      const spec = new Type("string")
+      const spec = new Type("String")
 
       assert.equal(spec.match("", { allowEmpty: true }), true)
       assert.equal(spec.match("", { allowEmpty: false }), false)
     })
 
     it("handles array type matching", () => {
-      const spec = new Type("array")
+      const spec = new Type("Array")
 
       assert.equal(spec.match([]), true)
       assert.equal(spec.match([1, 2, 3]), true)
@@ -196,7 +196,7 @@ describe("Type", () => {
     })
 
     it("rejects non-uniform arrays", () => {
-      const spec = new Type("string[]")
+      const spec = new Type("String[]")
 
       assert.equal(spec.match(["a", "b", "c"]), true)
       assert.equal(spec.match(["a", 1, "c"]), false) // mixed types
@@ -205,21 +205,21 @@ describe("Type", () => {
 
   describe("toString and toJSON", () => {
     it("toString returns string representation", () => {
-      const spec1 = new Type("string")
-      const spec2 = new Type("number[]")
-      const spec3 = new Type("string|number[]|boolean")
+      const spec1 = new Type("String")
+      const spec2 = new Type("Number[]")
+      const spec3 = new Type("String|Number[]|Boolean")
 
-      assert.equal(spec1.toString(), "string")
-      assert.equal(spec2.toString(), "number[]")
-      assert.equal(spec3.toString(), "string|number[]|boolean")
+      assert.equal(spec1.toString(), "String")
+      assert.equal(spec2.toString(), "Number[]")
+      assert.equal(spec3.toString(), "String|Number[]|Boolean")
     })
 
     it("toJSON returns structured data", () => {
-      const spec = new Type("string|number[]")
+      const spec = new Type("String|Number[]")
       const json = spec.toJSON()
 
       assert.equal(json.length, 2)
-      assert.equal(json.stringRepresentation, "string|number[]")
+      assert.equal(json.stringRepresentation, "String|Number[]")
       assert.ok(Array.isArray(json.specs))
       assert.equal(json.specs.length, 2)
     })
@@ -227,20 +227,20 @@ describe("Type", () => {
 
   describe("custom delimiter option", () => {
     it("uses custom delimiter when provided", () => {
-      const spec = new Type("string&number&boolean", { delimiter: "&" })
+      const spec = new Type("String&Number&Boolean", { delimiter: "&" })
 
       assert.equal(spec.length, 3)
-      assert.equal(spec.specs[0].typeName, "string")
-      assert.equal(spec.specs[1].typeName, "number")
-      assert.equal(spec.specs[2].typeName, "boolean")
+      assert.equal(spec.specs[0].typeName, "String")
+      assert.equal(spec.specs[1].typeName, "Number")
+      assert.equal(spec.specs[2].typeName, "Boolean")
     })
   })
 
   describe("edge cases", () => {
     it("handles all valid JavaScript types", () => {
       const validTypes = [
-        "string", "number", "boolean", "object", "function", "undefined",
-        "symbol", "bigint", "array", "date", "regexp", "error", "map", "set"
+        "String", "Number", "Boolean", "Object", "Function", "Undefined",
+        "Symbol", "Bigint", "Array", "Date", "RegExp", "Error", "Map", "Set"
       ]
 
       for (const type of validTypes) {
@@ -250,7 +250,7 @@ describe("Type", () => {
     })
 
     it("handles complex nested scenarios", () => {
-      const spec = new Type("object|string[]|function")
+      const spec = new Type("Object|String[]|Function")
 
       assert.equal(spec.match({}), true)
       assert.equal(spec.match(["a", "b"]), true)
@@ -259,13 +259,13 @@ describe("Type", () => {
     })
 
     it("validates invalid type specifications", () => {
-      assert.throws(() => new Type("badtype"), Sass)
-      assert.throws(() => new Type("string|badtype"), Sass)
+      assert.throws(() => new Type("bad-type"), Sass)
+      assert.throws(() => new Type("String|bad-type"), Sass)
       assert.throws(() => new Type(""), Sass)
     })
 
     it("correctly handles union type matching with arrays", () => {
-      const spec = new Type("string|number[]|boolean")
+      const spec = new Type("String|Number[]|Boolean")
 
       // Should match individual types
       assert.equal(spec.match("hello"), true)
@@ -281,8 +281,8 @@ describe("Type", () => {
     })
 
     it("respects allowEmpty for different value types", () => {
-      const stringSpec = new Type("string")
-      const arraySpec = new Type("string[]")
+      const stringSpec = new Type("String")
+      const arraySpec = new Type("String[]")
 
       // String emptiness
       assert.equal(stringSpec.match("", { allowEmpty: true }), true)

--- a/tests/unit/Valid.test.js
+++ b/tests/unit/Valid.test.js
@@ -82,67 +82,67 @@ describe("Valid", () => {
   describe("type", () => {
     it("passes for valid basic types", () => {
       // These should not throw
-      Valid.type("hello", "string")
-      Valid.type(123, "number")
-      Valid.type(true, "boolean")
-      Valid.type([], "array")
-      Valid.type({}, "object")
-      Valid.type(() => {}, "function")
+      Valid.type("hello", "String")
+      Valid.type(123, "Number")
+      Valid.type(true, "Boolean")
+      Valid.type([], "Array")
+      Valid.type({}, "Object")
+      Valid.type(() => {}, "Function")
     })
 
     it("throws Sass error for invalid types", () => {
       assert.throws(() => {
-        Valid.type(123, "string")
+        Valid.type(123, "String")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
-               error.message.includes("Expected string")
+               error.message.includes("Expected String")
       })
 
       assert.throws(() => {
-        Valid.type("hello", "number")
+        Valid.type("hello", "Number")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
-               error.message.includes("Expected number")
+               error.message.includes("Expected Number")
       })
     })
 
     it("works with type specifications", () => {
       // Array types
-      Valid.type([1, 2, 3], "number[]") // Should not throw
-      Valid.type(["a", "b"], "string[]") // Should not throw
+      Valid.type([1, 2, 3], "Number[]") // Should not throw
+      Valid.type(["a", "b"], "String[]") // Should not throw
 
       assert.throws(() => {
-        Valid.type([1, "mixed"], "number[]")
+        Valid.type([1, "mixed"], "Number[]")
       }, Sass)
     })
 
     it("works with union types", () => {
-      Valid.type("hello", "string|number") // Should not throw
-      Valid.type(123, "string|number") // Should not throw
+      Valid.type("hello", "String|Number") // Should not throw
+      Valid.type(123, "String|Number") // Should not throw
 
       assert.throws(() => {
-        Valid.type(true, "string|number")
+        Valid.type(true, "String|Number")
       }, Sass)
     })
 
     it("passes options to underlying type checking", () => {
       // Test with allowEmpty option
-      Valid.type("", "string", { allowEmpty: true }) // Should not throw
+      Valid.type("", "String", { allowEmpty: true }) // Should not throw
 
       assert.throws(() => {
-        Valid.type("", "string", { allowEmpty: false })
+        Valid.type("", "String", { allowEmpty: false })
       }, Sass)
     })
 
     it("provides detailed error messages", () => {
       assert.throws(() => {
-        Valid.type([1, "mixed"], "number[]")
+        Valid.type([1, "mixed"], "Number[]")
       }, (error) => {
         return error instanceof Sass &&
                error.message.includes("Invalid type") &&
-               error.message.includes("Expected number[]")
+               error.message.includes("Expected Number[]")
       })
     })
   })
@@ -168,9 +168,9 @@ describe("Valid", () => {
         }
       }
 
-      Valid.type(complexObject, "object") // Should not throw
-      Valid.type(complexObject.values, "number[]") // Should not throw
-      Valid.type(complexObject.nested.flag, "boolean") // Should not throw
+      Valid.type(complexObject, "Object") // Should not throw
+      Valid.type(complexObject.values, "Number[]") // Should not throw
+      Valid.type(complexObject.nested.flag, "Boolean") // Should not throw
     })
   })
 })


### PR DESCRIPTION
# Type System Overhaul

This PR updates the type system to use PascalCase for all type names, improving consistency and enabling support for custom class types. The changes include:

- Bumped version from 0.1.6 to 0.2.0 to reflect significant API changes
- Converted all type names to PascalCase (e.g., "string" → "String", "array" → "Array")
- Enhanced `typeOf()` to return constructor names for objects, enabling proper class type detection
- Added support for custom class types with PascalCase naming convention
- Updated `isBaseType()` and related methods to work with the new type naming system
- Fixed type checking for arrays to use the enhanced type system
- Updated all tests to reflect the new type naming convention

These changes make the type system more robust and consistent while maintaining backward compatibility through automatic capitalization of type names.