### PR TITLE
Add Collection class with array, object, set, and map utilities and bump version to 0.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {default as FS} from "./lib/FS.js"
 
 // Utility classes
 export {default as Cache} from "./lib/Cache.js"
+export {default as Collection} from "./lib/Collection.js"
 export {default as Data} from "./lib/Data.js"
 export {default as Glog} from "./lib/Glog.js"
 export {default as Sass} from "./lib/Sass.js"

--- a/src/lib/Collection.js
+++ b/src/lib/Collection.js
@@ -1,0 +1,108 @@
+import Data from "./Data.js"
+import Valid from "./Valid.js"
+
+export default class Collection {
+  static evalArray(collection, predicate, forward=true) {
+    const req = "Array"
+    const type = Data.typeOf(collection)
+
+    Valid.type(collection, req, `Invalid collection. Expected '${req}, got ${type}`)
+    Valid.type(predicate, "Function",
+      `Invalid predicate, expected 'Function', got ${Data.typeOf(predicate)}`)
+
+    const work = forward
+      ? Array.from(collection)
+      : Array.from(collection).toReversed()
+
+    for(let i = 0; i < work.length; i++) {
+      const result = predicate(work[i], i, collection) ?? null
+
+      if(result)
+        return result
+    }
+  }
+
+  static evalObject(collection, predicate) {
+    const req = "Object"
+    const type = Data.typeOf(collection)
+
+    Valid.type(collection, req, `Invalid collection. Expected '${req}, got ${type}`)
+    Valid.type(predicate, "Function",
+      `Invalid predicate, expected 'Function', got ${Data.typeOf(predicate)}`)
+
+    const work = Object.entries(collection)
+
+    for(let i = 0; i < work.length; i++) {
+      const result = predicate(work[i][1], work[i][0], collection)
+
+      if(result)
+        return result
+    }
+  }
+
+  static evalSet(collection, predicate) {
+    const req = "Set"
+    const type = Data.typeOf(collection)
+
+    Valid.type(collection, req, `Invalid collection. Expected '${req}, got ${type}`)
+    Valid.type(predicate, "Function",
+      `Invalid predicate, expected 'Function', got ${Data.typeOf(predicate)}`)
+
+    const work = Array.from(collection)
+
+    for(let i = 0; i < work.length; i++) {
+      const result = predicate(work[i], collection)
+
+      if(result)
+        return result
+    }
+  }
+
+  static evalMap(collection, predicate, forward=true) {
+    const req = "Map"
+    const type = Data.typeOf(collection)
+
+    Valid.type(collection, req, `Invalid collection. Expected '${req}, got ${type}`)
+    Valid.type(predicate, "Function",
+      `Invalid predicate, expected 'Function', got ${Data.typeOf(predicate)}`)
+
+    const work = forward
+      ? Array.from(collection)
+      : Array.from(collection).toReversed()
+
+    for(let i = 0; i < work.length; i++) {
+      const result = predicate(work[i][1], work[i][0], collection) ?? null
+
+      if(result)
+        return result
+    }
+  }
+
+  static zip(array1, array2) {
+    const minLength = Math.min(array1.length, array2.length)
+
+    return Array.from({length: minLength}, (_, i) => [array1[i], array2[i]])
+  }
+
+  static unzip(array) {
+    if(!Array.isArray(array) || array.length === 0) {
+      return [] // Handle empty or invalid input
+    }
+
+    // Determine the number of "unzipped" arrays needed
+    // This assumes all inner arrays have the same length, or we take the max length
+    const numUnzippedArrays = Math.max(...array.map(arr => arr.length))
+
+    // Initialize an array of empty arrays to hold the unzipped results
+    const unzipped = Array.from({length: numUnzippedArrays}, () => [])
+
+    // Iterate through the zipped array and populate the unzipped arrays
+    for(let i = 0; i < array.length; i++) {
+      for(let j = 0; j < numUnzippedArrays; j++) {
+        unzipped[j].push(array[i][j])
+      }
+    }
+
+    return unzipped
+  }
+}

--- a/src/types/Collection.d.ts
+++ b/src/types/Collection.d.ts
@@ -1,0 +1,138 @@
+// Implementation: ../lib/Collection.js
+// Type definitions for Collection utilities
+
+/**
+ * Collection utility functions for evaluating and manipulating arrays, objects, sets, and maps.
+ * Provides functional programming patterns for collection processing with consistent error handling.
+ */
+export default class Collection {
+  /**
+   * Evaluates an array with a predicate function, returning the first truthy result.
+   *
+   * @param collection - The array to evaluate
+   * @param predicate - Function called for each element: (element, index, array) => result
+   * @param forward - Whether to iterate forward (true) or backward (false). Default: true
+   * @returns The first truthy result from the predicate, or undefined if none found
+   *
+   * @throws {Sass} If collection is not an Array or predicate is not a Function
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const numbers = [1, 2, 3, 4, 5]
+   * const result = Collection.evalArray(numbers, (n, i) => n > 3 ? n * 2 : null)
+   * console.log(result) // 8 (first element > 3, doubled)
+   * ```
+   */
+  static evalArray<T, R>(
+    collection: T[],
+    predicate: (element: T, index: number, array: T[]) => R | null | undefined,
+    forward?: boolean
+  ): R | undefined
+
+  /**
+   * Evaluates an object with a predicate function, returning the first truthy result.
+   *
+   * @param collection - The object to evaluate
+   * @param predicate - Function called for each property: (value, key, object) => result
+   * @returns The first truthy result from the predicate, or undefined if none found
+   *
+   * @throws {Sass} If collection is not an Object or predicate is not a Function
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const obj = {a: 1, b: 2, c: 3}
+   * const result = Collection.evalObject(obj, (value, key) => value > 2 ? `${key}:${value}` : null)
+   * console.log(result) // "c:3"
+   * ```
+   */
+  static evalObject<T, R>(
+    collection: Record<string, T>,
+    predicate: (value: T, key: string, object: Record<string, T>) => R | null | undefined
+  ): R | undefined
+
+  /**
+   * Evaluates a Set with a predicate function, returning the first truthy result.
+   *
+   * @param collection - The Set to evaluate
+   * @param predicate - Function called for each element: (element, set) => result
+   * @returns The first truthy result from the predicate, or undefined if none found
+   *
+   * @throws {Sass} If collection is not a Set or predicate is not a Function
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const set = new Set([1, 2, 3, 4, 5])
+   * const result = Collection.evalSet(set, (n, s) => n > 3 ? n * 2 : null)
+   * console.log(result) // 8
+   * ```
+   */
+  static evalSet<T, R>(
+    collection: Set<T>,
+    predicate: (element: T, set: Set<T>) => R | null | undefined
+  ): R | undefined
+
+  /**
+   * Evaluates a Map with a predicate function, returning the first truthy result.
+   *
+   * @param collection - The Map to evaluate
+   * @param predicate - Function called for each entry: (value, key, map) => result
+   * @param forward - Whether to iterate forward (true) or backward (false). Default: true
+   * @returns The first truthy result from the predicate, or undefined if none found
+   *
+   * @throws {Sass} If collection is not a Map or predicate is not a Function
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const map = new Map([['a', 1], ['b', 2], ['c', 3]])
+   * const result = Collection.evalMap(map, (value, key) => value > 2 ? `${key}:${value}` : null)
+   * console.log(result) // "c:3"
+   * ```
+   */
+  static evalMap<K, V, R>(
+    collection: Map<K, V>,
+    predicate: (value: V, key: K, map: Map<K, V>) => R | null | undefined,
+    forward?: boolean
+  ): R | undefined
+
+  /**
+   * Zips two arrays together into an array of pairs.
+   *
+   * @param array1 - The first array
+   * @param array2 - The second array
+   * @returns Array of [element1, element2] pairs, length of shorter input array
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const result = Collection.zip([1, 2, 3], ['a', 'b', 'c'])
+   * console.log(result) // [[1, 'a'], [2, 'b'], [3, 'c']]
+   * ```
+   */
+  static zip<T, U>(array1: T[], array2: U[]): [T, U][]
+
+  /**
+   * Unzips an array of arrays into separate arrays.
+   *
+   * @param array - Array of arrays to unzip
+   * @returns Array of separate arrays, one for each position
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const zipped = [[1, 'a'], [2, 'b'], [3, 'c']]
+   * const result = Collection.unzip(zipped)
+   * console.log(result) // [[1, 2, 3], ['a', 'b', 'c']]
+   * ```
+   */
+  static unzip<T>(array: T[][]): T[][]
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -6,6 +6,7 @@ export { default as FS } from './FS.js'
 
 // Utility classes
 export { default as Cache } from './Cache.js'
+export { default as Collection } from './Collection.js'
 export { default as Data } from './Data.js'
 export { default as Glog } from './Glog.js'
 export { default as Sass } from './Sass.js'

--- a/tests/unit/Collection.test.js
+++ b/tests/unit/Collection.test.js
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+
+import { describe, it } from "node:test"
+import assert from "node:assert/strict"
+
+import { Collection } from "../../src/index.js"
+
+describe("Collection", () => {
+  describe("evalArray()", () => {
+    it("handles normal cases", () => {
+      const array = [1, 2, 3, 4, 5]
+      const result = Collection.evalArray(array, n => n > 3 ? n * 2 : null)
+      assert.equal(result, 8) // 4 * 2 = 8
+    })
+
+    it("returns undefined when no match found", () => {
+      const array = [1, 2, 3]
+      const result = Collection.evalArray(array, n => n > 5 ? n : null)
+      assert.equal(result, undefined)
+    })
+
+    it("handles empty arrays", () => {
+      const result = Collection.evalArray([], n => n > 0 ? n : null)
+      assert.equal(result, undefined)
+    })
+
+    it("validates input types", () => {
+      assert.throws(() => Collection.evalArray("not array", () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalArray([], "not function"), /Invalid type/)
+    })
+
+    it("passes correct arguments to predicate", () => {
+      const array = ["a", "b", "c"]
+      let capturedArgs = []
+
+      Collection.evalArray(array, (element, index, arr) => {
+        capturedArgs.push([element, index, arr])
+        return null
+      })
+
+      assert.deepEqual(capturedArgs[0], ["a", 0, array])
+      assert.deepEqual(capturedArgs[1], ["b", 1, array])
+      assert.deepEqual(capturedArgs[2], ["c", 2, array])
+    })
+
+    it("supports forward iteration (default)", () => {
+      const array = [1, 2, 3, 4]
+      const results = []
+
+      Collection.evalArray(array, n => {
+        results.push(n)
+        return n === 2 ? "found" : null
+      })
+
+      assert.deepEqual(results, [1, 2])
+    })
+
+    it("supports backward iteration", () => {
+      const array = [1, 2, 3, 4]
+      const results = []
+
+      Collection.evalArray(array, n => {
+        results.push(n)
+        return n === 3 ? "found" : null
+      }, false)
+
+      assert.deepEqual(results, [4, 3])
+    })
+  })
+
+  describe("evalObject()", () => {
+    it("handles normal cases", () => {
+      const obj = {a: 1, b: 2, c: 3}
+      const result = Collection.evalObject(obj, (value, key) => value > 2 ? `${key}:${value}` : null)
+      assert.equal(result, "c:3")
+    })
+
+    it("returns undefined when no match found", () => {
+      const obj = {a: 1, b: 2}
+      const result = Collection.evalObject(obj, value => value > 5 ? value : null)
+      assert.equal(result, undefined)
+    })
+
+    it("handles empty objects", () => {
+      const result = Collection.evalObject({}, value => value > 0 ? value : null)
+      assert.equal(result, undefined)
+    })
+
+    it("validates input types", () => {
+      assert.throws(() => Collection.evalObject("not object", () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalObject({}, "not function"), /Invalid type/)
+    })
+
+    it("passes correct arguments to predicate", () => {
+      const obj = {x: 10, y: 20}
+      let capturedArgs = []
+
+      Collection.evalObject(obj, (value, key, object) => {
+        capturedArgs.push([value, key, object])
+        return null
+      })
+
+      assert.deepEqual(capturedArgs[0], [10, "x", obj])
+      assert.deepEqual(capturedArgs[1], [20, "y", obj])
+    })
+  })
+
+  describe("evalSet()", () => {
+    it("handles normal cases", () => {
+      const set = new Set([1, 2, 3, 4, 5])
+      const result = Collection.evalSet(set, n => n > 3 ? n * 2 : null)
+      assert.equal(result, 8) // 4 * 2 = 8
+    })
+
+    it("returns undefined when no match found", () => {
+      const set = new Set([1, 2, 3])
+      const result = Collection.evalSet(set, n => n > 5 ? n : null)
+      assert.equal(result, undefined)
+    })
+
+    it("handles empty sets", () => {
+      const result = Collection.evalSet(new Set(), n => n > 0 ? n : null)
+      assert.equal(result, undefined)
+    })
+
+    it("validates input types", () => {
+      assert.throws(() => Collection.evalSet("not set", () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalSet(new Set(), "not function"), /Invalid type/)
+    })
+
+    it("passes correct arguments to predicate", () => {
+      const set = new Set(["a", "b"])
+      let capturedArgs = []
+
+      Collection.evalSet(set, (element, setRef) => {
+        capturedArgs.push([element, setRef])
+        return null
+      })
+
+      assert.equal(capturedArgs.length, 2)
+      assert.ok(capturedArgs[0][1] === set)
+      assert.ok(capturedArgs[1][1] === set)
+    })
+  })
+
+  describe("evalMap()", () => {
+    it("handles normal cases", () => {
+      const map = new Map([['a', 1], ['b', 2], ['c', 3]])
+      const result = Collection.evalMap(map, (value, key) => value > 2 ? `${key}:${value}` : null)
+      assert.equal(result, "c:3")
+    })
+
+    it("returns undefined when no match found", () => {
+      const map = new Map([['a', 1], ['b', 2]])
+      const result = Collection.evalMap(map, value => value > 5 ? value : null)
+      assert.equal(result, undefined)
+    })
+
+    it("handles empty maps", () => {
+      const result = Collection.evalMap(new Map(), value => value > 0 ? value : null)
+      assert.equal(result, undefined)
+    })
+
+    it("validates input types", () => {
+      assert.throws(() => Collection.evalMap("not map", () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalMap(new Map(), "not function"), /Invalid type/)
+    })
+
+    it("passes correct arguments to predicate", () => {
+      const map = new Map([['x', 10], ['y', 20]])
+      let capturedArgs = []
+
+      Collection.evalMap(map, (value, key, mapRef) => {
+        capturedArgs.push([value, key, mapRef])
+        return null
+      })
+
+      assert.deepEqual(capturedArgs[0], [10, "x", map])
+      assert.deepEqual(capturedArgs[1], [20, "y", map])
+    })
+
+    it("supports forward iteration (default)", () => {
+      const map = new Map([['a', 1], ['b', 2], ['c', 3]])
+      const results = []
+
+      Collection.evalMap(map, (value, key) => {
+        results.push(key)
+        return value === 2 ? "found" : null
+      })
+
+      assert.deepEqual(results, ["a", "b"])
+    })
+
+    it("supports backward iteration", () => {
+      const map = new Map([['a', 1], ['b', 2], ['c', 3]])
+      const results = []
+
+      Collection.evalMap(map, (value, key) => {
+        results.push(key)
+        return value === 2 ? "found" : null
+      }, false)
+
+      assert.deepEqual(results, ["c", "b"])
+    })
+  })
+
+  describe("zip()", () => {
+    it("zips arrays of equal length", () => {
+      const result = Collection.zip([1, 2, 3], ['a', 'b', 'c'])
+      assert.deepEqual(result, [[1, 'a'], [2, 'b'], [3, 'c']])
+    })
+
+    it("zips arrays of unequal length", () => {
+      const result = Collection.zip([1, 2, 3, 4], ['a', 'b'])
+      assert.deepEqual(result, [[1, 'a'], [2, 'b']])
+    })
+
+    it("handles empty arrays", () => {
+      const result = Collection.zip([], [])
+      assert.deepEqual(result, [])
+    })
+
+    it("handles one empty array", () => {
+      const result = Collection.zip([1, 2], [])
+      assert.deepEqual(result, [])
+    })
+  })
+
+  describe("unzip()", () => {
+    it("unzips arrays correctly", () => {
+      const zipped = [[1, 'a'], [2, 'b'], [3, 'c']]
+      const result = Collection.unzip(zipped)
+      assert.deepEqual(result, [[1, 2, 3], ['a', 'b', 'c']])
+    })
+
+    it("handles empty input", () => {
+      const result = Collection.unzip([])
+      assert.deepEqual(result, [])
+    })
+
+    it("handles invalid input", () => {
+      const result = Collection.unzip("not array")
+      assert.deepEqual(result, [])
+    })
+
+    it("handles jagged arrays", () => {
+      const zipped = [[1, 2], [3], [4, 5, 6]]
+      const result = Collection.unzip(zipped)
+      assert.deepEqual(result, [[1, 3, 4], [2, undefined, 5], [undefined, undefined, 6]])
+    })
+  })
+
+  describe("error scenarios", () => {
+    it("handles null and undefined inputs", () => {
+      assert.throws(() => Collection.evalArray(null, () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalArray(undefined, () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalObject(null, () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalSet(null, () => {}), /Invalid type/)
+      assert.throws(() => Collection.evalMap(null, () => {}), /Invalid type/)
+    })
+
+    it("handles complex nested scenarios", () => {
+      const complex = {
+        users: [
+          {id: 1, name: "Alice"},
+          {id: 2, name: "Bob"}
+        ],
+        settings: new Map([['theme', 'dark']])
+      }
+
+      // Test nested array evaluation
+      const userResult = Collection.evalArray(complex.users, user => user.id === 2 ? user.name : null)
+      assert.equal(userResult, "Bob")
+
+      // Test nested map evaluation
+      const settingResult = Collection.evalMap(complex.settings, (value, key) => key === 'theme' ? value : null)
+      assert.equal(settingResult, "dark")
+    })
+  })
+})


### PR DESCRIPTION
# Add Collection Utility Class

This PR adds a new `Collection` utility class that provides methods for evaluating and manipulating different collection types (arrays, objects, sets, and maps). The class includes:

- `evalArray()` - Evaluates array elements with a predicate function, returning the first truthy result
- `evalObject()` - Evaluates object properties with a predicate function
- `evalSet()` - Evaluates Set elements with a predicate function
- `evalMap()` - Evaluates Map entries with a predicate function
- `zip()` - Combines two arrays into an array of pairs
- `unzip()` - Separates an array of arrays into individual arrays

Each method includes proper type validation and consistent error handling. The implementation is fully tested with comprehensive unit tests covering normal usage, edge cases, and error scenarios.

TypeScript definitions are included with detailed JSDoc comments and examples for each method.

Version bumped to 0.2.1.