### PR TITLE
Fix FS.relativeOrAbsolutePath for FileObject sources

### DIFF
--- a/src/lib/FS.js
+++ b/src/lib/FS.js
@@ -115,7 +115,11 @@ export default class FS {
    * @returns {string} The relative path from `from` to `to`, or the absolute path if not reachable
    */
   static relativeOrAbsolutePath(from, to) {
-    const relative = path.relative(from.path, to.path)
+    const fromBasePath = from.isDirectory
+      ? from.path
+      : from.directory?.path ?? path.dirname(from.path)
+
+    const relative = path.relative(fromBasePath, to.path)
 
     return relative.startsWith("..")
       ? to.path

--- a/tests/unit/FS.test.js
+++ b/tests/unit/FS.test.js
@@ -84,6 +84,15 @@ describe("FS", () => {
       assert.equal(result, "/home/user/project/lib/utils.js")
     })
 
+    it("relativeOrAbsolutePath uses containing directory for files", () => {
+      const from = new FileObject("/home/user/project/src/index.js")
+      const to = new FileObject("/home/user/project/src/utils/helper.js")
+
+      const result = FS.relativeOrAbsolutePath(from, to)
+
+      assert.equal(result, path.join("utils", "helper.js"))
+    })
+
     it("relativeOrAbsolutePath returns absolute path when outside scope", () => {
       const from = new FileObject("/home/user/project/src/index.js")
       const to = new FileObject("/etc/config.txt")


### PR DESCRIPTION
## Summary
- fix FS.relativeOrAbsolutePath to base relative calculations on a file's parent directory
- add a regression test ensuring relative paths from FileObject sources stay within the directory scope

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68d84c3d02b08333bb43688b31fa9129