### PR TITLE
Fix locale-sensitive casing regression in FS fdType map

### DIFF
--- a/src/lib/FS.js
+++ b/src/lib/FS.js
@@ -9,7 +9,7 @@ import Sass from "./Sass.js"
 import Valid from "./Valid.js"
 
 const fdTypes = Object.freeze(["file", "directory"])
-const upperFdTypes = Object.freeze(fdTypes.map(type => type.toLocaleUpperCase()))
+const upperFdTypes = Object.freeze(fdTypes.map(type => type.toUpperCase()))
 const fdType = Object.freeze(await Data.allocateObject(upperFdTypes, fdTypes))
 
 export default class FS {


### PR DESCRIPTION
## Summary
- revert the fdType key generation to use locale-invariant `toUpperCase()`
- ensure `FS.fdType` retains stable `FILE` and `DIRECTORY` keys across locales

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d851720e708333926eaa03986e77f1