### PR TITLE
Fix Util.regexify to handle all line ending types and bump version to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/Util.js
+++ b/src/lib/Util.js
@@ -313,7 +313,7 @@ export default class Util {
 
     return new RegExp(
       input
-        .split("\n")
+        .split(/\r\n|\r|\n/)
         .map(i => trim ? i.trim() : i)
         .filter(i => trim ? Boolean(i) : true)
         .join("")


### PR DESCRIPTION
# Update RegExp handling in Util.js to support all line endings

This PR updates the `Util.js` file to improve the handling of line endings in regular expressions. The change replaces the simple `split("\n")` with a more comprehensive `split(/\r\n|\r|\n/)` pattern that properly handles all common line ending formats:

- Windows-style CRLF (`\r\n`)
- Classic Mac-style CR (`\r`)
- Unix/Linux-style LF (`\n`)

This ensures consistent behavior across different platforms and file formats. Version bumped to 0.2.4.