### PR TITLE
Add Collection.trimArray methods and bump version to 0.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/Collection.js
+++ b/src/lib/Collection.js
@@ -522,4 +522,41 @@ export default class Collection {
       return acc
     }, {})
   }
+
+  static trimArray(arr, except=[]) {
+    Valid.type(arr, "Array")
+    Valid.type(except, "Array")
+
+    Collection.trimArrayLeft(arr, except)
+    Collection.trimArrayRight(arr, except)
+
+    return arr
+  }
+
+  static trimArrayRight(arr, except=[]) {
+    Valid.type(arr, "Array")
+    Valid.type(except, "Array")
+
+    arr.reverse()
+    Collection.trimArrayLeft(arr, except)
+    arr.reverse()
+
+    return arr
+  }
+
+  static trimArrayLeft(arr, except=[]) {
+    Valid.type(arr, "Array")
+    Valid.type(except, "Array")
+
+    while(arr.length > 0) {
+      const value = arr[0]
+
+      if(value || except.includes(value))
+        break
+
+      arr.shift()
+    }
+
+    return arr
+  }
 }

--- a/src/types/Collection.d.ts
+++ b/src/types/Collection.d.ts
@@ -237,4 +237,64 @@ export default class Collection {
    * ```
    */
   static flattenObjectArray(objects: Array<Record<string, unknown>>): Record<string, Array<unknown>>
+
+  /**
+   * Trims falsy values from both ends of an array.
+   *
+   * @param arr - The array to trim
+   * @param except - Array of values to exclude from trimming (default: [])
+   * @returns The trimmed array (modified in place)
+   *
+   * @throws {Sass} If arr or except is not an Array
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const arr = [null, 0, 1, 2, "", undefined]
+   * Collection.trimArray(arr)
+   * console.log(arr) // [1, 2]
+   * ```
+   */
+  static trimArray<T>(arr: Array<T>, except?: Array<T>): Array<T>
+
+  /**
+   * Trims falsy values from the right end of an array.
+   *
+   * @param arr - The array to trim
+   * @param except - Array of values to exclude from trimming (default: [])
+   * @returns The trimmed array (modified in place)
+   *
+   * @throws {Sass} If arr or except is not an Array
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const arr = [1, "", undefined]
+   * Collection.trimArrayRight(arr)
+   * console.log(arr) // [1]
+   * ```
+   */
+  static trimArrayRight<T>(arr: Array<T>, except?: Array<T>): Array<T>
+
+  /**
+   * Trims falsy values from the left end of an array.
+   *
+   * @param arr - The array to trim
+   * @param except - Array of values to exclude from trimming (default: [])
+   * @returns The trimmed array (modified in place)
+   *
+   * @throws {Sass} If arr or except is not an Array
+   *
+   * @example
+   * ```typescript
+   * import { Collection } from '@gesslar/toolkit'
+   *
+   * const arr = [null, undefined, "value"]
+   * Collection.trimArrayLeft(arr)
+   * console.log(arr) // ["value"]
+   * ```
+   */
+  static trimArrayLeft<T>(arr: Array<T>, except?: Array<T>): Array<T>
 }

--- a/tests/unit/Collection.test.js
+++ b/tests/unit/Collection.test.js
@@ -496,6 +496,50 @@ describe("Collection", () => {
 
       assert.deepEqual(result, [2, 4])
     })
+
+    it("trimArray removes falsy elements from both ends", () => {
+      const arr = [null, 0, 1, 2, "", undefined]
+      const trimmed = Collection.trimArray(arr)
+
+      assert.strictEqual(trimmed, arr)
+      assert.deepEqual(arr, [1, 2])
+    })
+
+    it("trimArrayLeft trims leading falsy values while honoring exceptions", () => {
+      const arr = [0, false, 1]
+
+      Collection.trimArrayLeft(arr, [0])
+
+      assert.deepEqual(arr, [0, false, 1])
+
+      const arr2 = [null, undefined, "value"]
+
+      Collection.trimArrayLeft(arr2)
+
+      assert.deepEqual(arr2, ["value"])
+    })
+
+    it("trimArrayRight trims trailing falsy values and respects exceptions", () => {
+      const arr = [1, "", undefined]
+
+      Collection.trimArrayRight(arr)
+
+      assert.deepEqual(arr, [1])
+
+      const arr2 = [1, "", 0]
+
+      Collection.trimArrayRight(arr2, [0])
+
+      assert.deepEqual(arr2, [1, "", 0])
+    })
+
+    it("trimArrayLeft handles empty arrays safely", () => {
+      const arr = []
+
+      Collection.trimArrayLeft(arr)
+
+      assert.deepEqual(arr, [])
+    })
   })
 
   describe("flattenObjectArray()", () => {


### PR DESCRIPTION
# Add Array Trimming Methods to Collection Class

Added three new static methods to the Collection class for trimming falsy values from arrays:

- `trimArray`: Removes falsy values from both ends of an array
- `trimArrayLeft`: Removes falsy values from the beginning of an array
- `trimArrayRight`: Removes falsy values from the end of an array

All methods:
- Modify the array in place and return the modified array
- Accept an optional `except` parameter to specify falsy values that should be preserved
- Include TypeScript type definitions with examples
- Are fully tested with unit tests

Bumped package version to 0.2.6.