### PR TITLE
Refactor Collection.flattenObjectArray and add transposeObjects method, bump to v0.2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/Collection.js
+++ b/src/lib/Collection.js
@@ -498,31 +498,6 @@ export default class Collection {
     return result
   }
 
-  static flattenObjectArray(objects) {
-    const req = "Array"
-    const type = Data.typeOf(objects)
-
-    Valid.type(objects, req, `Invalid objects array. Expected '${req}', got '${type}'`)
-
-    return objects.reduce((acc, curr) => {
-      const elemType = Data.typeOf(curr)
-
-      if(!Data.isPlainObject(curr))
-        throw Sass.new(`Invalid array element. Expected plain object, got '${elemType}'`)
-
-      Valid.prototypePollutionProtection(Object.keys(curr))
-
-      Object.entries(curr).forEach(([key, value]) => {
-        if(!acc[key])
-          acc[key] = []
-
-        acc[key].push(value)
-      })
-
-      return acc
-    }, {})
-  }
-
   static trimArray(arr, except=[]) {
     Valid.type(arr, "Array")
     Valid.type(except, "Array")
@@ -558,5 +533,36 @@ export default class Collection {
     }
 
     return arr
+  }
+
+  static transposeObjects(objects) {
+    const req = "Array"
+    const type = Data.typeOf(objects)
+
+    Valid.type(objects, req, `Invalid objects array. Expected '${req}', got '${type}'`)
+
+    return objects.reduce((acc, curr) => {
+      const elemType = Data.typeOf(curr)
+
+      if(!Data.isPlainObject(curr))
+        throw Sass.new(`Invalid array element. Expected plain object, got '${elemType}'`)
+
+      Valid.prototypePollutionProtection(Object.keys(curr))
+
+      Object.entries(curr).forEach(([key, value]) => {
+        if(!acc[key])
+          acc[key] = []
+
+        acc[key].push(value)
+      })
+
+      return acc
+    }, {})
+  }
+
+  static flattenObjectArray(input) {
+    const flattened = Array.isArray(input) ? input.flat() : input
+
+    return Collection.transposeObjects(flattened)
   }
 }

--- a/src/types/Collection.d.ts
+++ b/src/types/Collection.d.ts
@@ -214,29 +214,45 @@ export default class Collection {
   static allocateObject(source: Array<unknown>, spec: Array<unknown> | ((source: Array<unknown>) => Promise<Array<unknown>> | Array<unknown>)): Promise<Record<string, unknown>>
 
   /**
-   * Flattens an array of plain objects into a single object where each key contains
-   * an array of all values for that key across all input objects.
+   * Flattens one level of an array of plain objects, transposing values so each
+   * key maps to the collected values from every object.
    *
-   * @param objects - Array of plain objects to flatten
+   * Accepts either a simple array of objects or an array that mixes objects and
+   * nested object arrays (one level deep). Nested arrays are flattened before
+   * transposition.
+   *
+   * @param input - Array of plain objects (optionally containing nested arrays)
    * @returns Object with keys mapped to arrays of values from all input objects
    *
-   * @throws {Sass} If objects is not an Array or if any element is not a plain object
+   * @throws {Sass} If input is not an Array or if any element is not a plain object after flattening
    *
    * @example
    * ```typescript
    * import { Collection } from '@gesslar/toolkit'
    *
    * const objects = [
-   *   { name: 'Alice', age: 25 },
-   *   { name: 'Bob', age: 30 },
-   *   { name: 'Charlie', age: 35 }
+   *   [{ name: 'Alice', age: 25 }],
+   *   { name: 'Bob', age: 30 }
    * ]
    *
    * const result = Collection.flattenObjectArray(objects)
-   * // result: { name: ['Alice', 'Bob', 'Charlie'], age: [25, 30, 35] }
+   * // result: { name: ['Alice', 'Bob'], age: [25, 30] }
    * ```
    */
-  static flattenObjectArray(objects: Array<Record<string, unknown>>): Record<string, Array<unknown>>
+  static flattenObjectArray(
+    input: Array<Record<string, unknown> | Array<Record<string, unknown>>>
+  ): Record<string, Array<unknown>>
+
+  /**
+   * Transposes an array of plain objects into an object of arrays, keyed by the
+   * original object keys.
+   *
+   * @param objects - Array of plain objects to transpose
+   * @returns Object with keys mapped to arrays of values from the input objects
+   *
+   * @throws {Sass} If objects is not an Array or if any element is not a plain object
+   */
+  static transposeObjects(objects: Array<Record<string, unknown>>): Record<string, Array<unknown>>
 
   /**
    * Trims falsy values from both ends of an array.

--- a/tests/unit/Collection.test.js
+++ b/tests/unit/Collection.test.js
@@ -631,12 +631,35 @@ describe("Collection", () => {
       })
     })
 
+    it("flattens nested arrays of objects", () => {
+      const objects = [
+        [
+          { name: 'Alice', age: 25 },
+          { name: 'Avery', age: 28 }
+        ],
+        { name: 'Bob', age: 30 }
+      ]
+
+      const result = Collection.flattenObjectArray(objects)
+
+      assert.deepEqual(result, {
+        name: ['Alice', 'Avery', 'Bob'],
+        age: [25, 28, 30]
+      })
+    })
+
+    it("treats nested empty arrays as empty input", () => {
+      const result = Collection.flattenObjectArray([[]])
+
+      assert.deepEqual(result, {})
+    })
+
     it("validates input types", () => {
       assert.throws(() => Collection.flattenObjectArray(null), /Invalid type/)
       assert.throws(() => Collection.flattenObjectArray("not array"), /Invalid type/)
       assert.throws(() => Collection.flattenObjectArray([new Date()]), /Invalid array element/)
-      assert.throws(() => Collection.flattenObjectArray([[]]), /Invalid array element/)
       assert.throws(() => Collection.flattenObjectArray([null]), /Invalid array element/)
+      assert.throws(() => Collection.flattenObjectArray([[new Date()]]), /Invalid array element/)
     })
 
     it("prevents prototype pollution", () => {
@@ -647,6 +670,26 @@ describe("Collection", () => {
       ]
 
       assert.throws(() => Collection.flattenObjectArray(objects), /don't pee in your pool/)
+    })
+  })
+
+  describe("transposeObjects()", () => {
+    it("transposes object arrays into keyed arrays", () => {
+      const objects = [
+        { name: 'Alice', age: 25 },
+        { name: 'Bob', age: 30 }
+      ]
+
+      const result = Collection.transposeObjects(objects)
+
+      assert.deepEqual(result, {
+        name: ['Alice', 'Bob'],
+        age: [25, 30]
+      })
+    })
+
+    it("throws when encountering non-plain objects", () => {
+      assert.throws(() => Collection.transposeObjects([new Date()]), /Invalid array element/)
     })
   })
 })


### PR DESCRIPTION
# Refactor Collection.flattenObjectArray and add transposeObjects method

This PR refactors the `Collection.flattenObjectArray` method to handle nested arrays of objects and introduces a new `Collection.transposeObjects` method.

Key changes:
- Added `transposeObjects` method that converts an array of objects into an object of arrays
- Refactored `flattenObjectArray` to first flatten nested arrays before transposition
- Updated TypeScript definitions to document the new behavior
- Added tests for handling nested arrays and the new `transposeObjects` method
- Bumped package version to 0.2.7

The refactored `flattenObjectArray` now accepts either a simple array of objects or an array that contains a mix of objects and nested arrays of objects (one level deep).