### PR TITLE
Add FileObject.import() method for dynamic ESM module loading and bump to v0.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/FileObject.js
+++ b/src/lib/FileObject.js
@@ -353,11 +353,11 @@ export default class FileObject extends FS {
   async read(encoding="utf8") {
     const filePath = this.path
 
-    if(!(await this.exists))
-      throw Sass.new(`No such file '${filePath}'`)
-
     if(!filePath)
       throw Sass.new("No absolute path in file map")
+
+    if(!(await this.exists))
+      throw Sass.new(`No such file '${filePath}'`)
 
     return await fs.readFile(filePath, encoding)
   }
@@ -408,5 +408,22 @@ export default class FileObject extends FS {
     }
 
     throw Sass.new(`Content is neither valid JSON5 nor valid YAML:\n'${this.path}'`)
+  }
+
+  /**
+   * Loads a file as a module and returns it.
+   *
+   * @returns {Promise<object>} The file contents as a module.
+   */
+  async import() {
+    const fileUri = this.uri
+
+    if(!fileUri)
+      throw Sass.new("No URI in file map")
+
+    if(!(await this.exists))
+      throw Sass.new(`No such file '${fileUri}'`)
+
+    return await import(fileUri)
   }
 }

--- a/src/types/FileObject.d.ts
+++ b/src/types/FileObject.d.ts
@@ -326,4 +326,27 @@ export default class FileObject extends FS {
 
   /** Load an object from JSON5 or YAML file with type specification */
   loadData(type?: 'json' | 'json5' | 'yaml' | 'any', encoding?: string): Promise<unknown>
+
+  /**
+   * Dynamically import the file using the resolved file URI.
+   *
+   * Uses Node.js' native dynamic `import()` under the hood, allowing consumers to load
+   * ESM modules from disk with full path resolution handled by FileObject. The method
+   * verifies the file exists before attempting the import to provide clearer error
+   * messaging and prevent low-level loader failures.
+   *
+   * @typeParam TModule - Expected module shape. Defaults to a loose record to help with
+   * module namespace typing.
+   *
+   * @returns The imported module namespace object.
+   *
+   * @throws {Error} When the file does not exist or the path cannot be converted to a URI.
+   *
+   * @example
+   * ```typescript
+   * const configModule = await file.import<{ default: Config }>()
+   * const config = configModule.default
+   * ```
+   */
+  import<TModule = Record<string, unknown>>(): Promise<TModule>
 }

--- a/tests/unit/FileObject.test.js
+++ b/tests/unit/FileObject.test.js
@@ -280,6 +280,48 @@ describe("FileObject", () => {
     })
   })
 
+  describe("import()", () => {
+    let moduleDir
+
+    beforeEach(async () => {
+      moduleDir = await TestUtils.createTestDir("file-import-test")
+    })
+
+    afterEach(async () => {
+      if(moduleDir) {
+        await TestUtils.cleanupTestDir(moduleDir)
+      }
+    })
+
+    it("imports ESM module using file URI", async () => {
+      const modulePath = path.join(moduleDir, "sample-module.js")
+      const moduleSource = [
+        "export const answer = 42",
+        "export default function greet(name) {",
+        "  return `hello ${name}`",
+        "}"
+      ].join("\n")
+
+      await fs.writeFile(modulePath, moduleSource, "utf8")
+
+      const file = new FileObject(modulePath)
+      const moduleNamespace = await file.import()
+
+      assert.equal(moduleNamespace.answer, 42)
+      assert.equal(moduleNamespace.default("world"), "hello world")
+    })
+
+    it("throws Sass error when module is missing", async () => {
+      const missingPath = path.join(moduleDir, "missing-module.js")
+      const file = new FileObject(missingPath)
+
+      await assert.rejects(
+        () => file.import(),
+        Sass
+      )
+    })
+  })
+
   describe("loadData method", () => {
     let jsonFile, yamlFile, invalidFile
 


### PR DESCRIPTION
# Add `import()` method to FileObject

This PR adds a new `import()` method to the FileObject class that allows dynamically importing a file as an ES module using its resolved URI. The method:

- Verifies the file exists before attempting to import
- Provides clear error messages when the file is missing or the URI can't be resolved
- Returns the imported module namespace object
- Includes TypeScript typings with generic support for module type specification

The implementation uses Node.js' native dynamic `import()` under the hood, making it easy to load ESM modules from disk with path resolution handled by FileObject.

Example usage:
```typescript
const configModule = await file.import<{ default: Config }>()
const config = configModule.default
```

Comprehensive tests have been added to verify the functionality works correctly.