### PR TITLE
Fix Sass error handling to use empty string instead of null

### DIFF
--- a/src/lib/Sass.js
+++ b/src/lib/Sass.js
@@ -112,7 +112,7 @@ export default class Sass extends Error {
         ...rest
           .split("\n")
           .map(line => {
-            const at = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups?.at ?? null
+            const at = line.match(/^\s{4}at\s(?<at>.*)$/)?.groups?.at ?? ""
 
             return at
               ? `* ${at}`


### PR DESCRIPTION
Changed the default value for `at` from `null` to an empty string in the error handling logic of the Sass class. This ensures that when no match is found in the error stack trace, an empty string is used instead of null, which can prevent potential issues when processing error messages.