### PR TITLE
Clarify FileObject path documentation

### DIFF
--- a/src/lib/FileObject.js
+++ b/src/lib/FileObject.js
@@ -162,18 +162,18 @@ export default class FileObject extends FS {
   }
 
   /**
-   * Return the user-supplied path
+   * Return the normalized path that was provided to the constructor.
    *
-   * @returns {string} The file path
+   * @returns {string} The sanitized user-supplied file path
    */
   get supplied() {
     return this.#meta.supplied
   }
 
   /**
-   * Return the resolved path as passed to the constructor.
+   * Return the fully resolved absolute path to the file on disk.
    *
-   * @returns {string} The file path
+   * @returns {string} The fully resolved absolute file path
    */
   get path() {
     return this.#meta.path


### PR DESCRIPTION
## Summary
- clarify that FileObject.path returns the fully resolved absolute path
- adjust the supplied getter comment to note the normalized path value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690af5d258488333882a8b0b3c648c6a