### PR TITLE
Fix Logger comment wording

### DIFF
--- a/src/lib/Logger.js
+++ b/src/lib/Logger.js
@@ -8,7 +8,7 @@
         options { depth: 0, colors: false, compact: 3 }.
   * %d: Number will be used to convert all values except BigInt and Symbol.
   * %i: parseInt(value, 10) is used for all values except BigInt and Symbol.
-  * %f: parseFloat(value) is used for all values expect Symbol.
+  * %f: parseFloat(value) is used for all values except Symbol.
   * %j: JSON. Replaced with the string '[Circular]' if the argument contains
         circular references.
   * %o: Object. A string representation of an object with generic JavaScript


### PR DESCRIPTION
## Summary
- correct the %f bullet comment in `Logger.js` to say "except Symbol"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690af5d01088833384b6e71ac2589e39