### PR TITLE
Add GitHub release workflow and update version placeholders in README

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+name: Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Run tests
+        run: npm test
+
+      - name: Derive version and tag from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "JSON.parse(require('fs').readFileSync('package.json', 'utf8')).version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure tag does not already exist
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists locally."
+            exit 1
+          fi
+
+          if git ls-remote --exit-code origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists on origin."
+            exit 1
+          fi
+
+      - name: Update README version placeholder
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = 'README.md';
+          const version = process.env.VERSION;
+          const content = fs.readFileSync(path, 'utf8');
+          const updated = content.replace(/__VERSION__/g, version);
+          if (content === updated) {
+            console.log('No __VERSION__ placeholders found to update.');
+          }
+          fs.writeFileSync(path, updated);
+          NODE
+
+      - name: Commit README update (if needed)
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if git diff --quiet; then
+            echo "No README changes to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "docs: update README for ${TAG}"
+          git push origin "HEAD:${BRANCH}"
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          target_commitish: HEAD
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ available in the browser version.
 **Browser via CDN (no install):**
 
 - jsDelivr (runtime only):
-  `https://cdn.jsdelivr.net/npm/@gesslar/toolkit/browser`
+  `https://cdn.jsdelivr.net/npm/@gesslar/toolkit@__VERSION__/browser`
 - esm.sh (runtime + optional types):
-  `https://esm.sh/@gesslar/toolkit@0.8.0/browser`
-  `https://esm.sh/@gesslar/toolkit@0.8.0/browser?dts` (serves `.d.ts` for editors)
+  `https://esm.sh/@gesslar/toolkit@__VERSION__/browser`
+  `https://esm.sh/@gesslar/toolkit@__VERSION__/browser?dts` (serves `.d.ts` for editors)
 
 Notes:
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/toolkit",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Unlicense",
       "dependencies": {
         "@gesslar/colours": "^0.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# Add GitHub Actions release workflow and version placeholder in README

This PR adds a new GitHub Actions workflow for automated releases and updates the version references in the README:

1. Added `.github/workflows/release.yml` that:
   - Runs on manual trigger (workflow_dispatch)
   - Checks out code, sets up Node.js 22.x
   - Runs linting and tests
   - Extracts version from package.json
   - Verifies the tag doesn't already exist
   - Updates version placeholders in README
   - Creates a GitHub release with auto-generated notes

2. Modified README.md to use `__VERSION__` placeholders in CDN URLs instead of hardcoded versions

3. Bumped package version from 1.0.0 to 1.0.1

The release workflow ensures consistent versioning across the codebase and simplifies the release process.