### PR TITLE
Disable automatic README version updates and bump version to 1.0.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,36 +52,36 @@ jobs:
             exit 1
           fi
 
-      - name: Update README version placeholder
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const path = 'README.md';
-          const version = process.env.VERSION;
-          const content = fs.readFileSync(path, 'utf8');
-          const updated = content.replace(/__VERSION__/g, version);
-          if (content === updated) {
-            console.log('No __VERSION__ placeholders found to update.');
-          }
-          fs.writeFileSync(path, updated);
-          NODE
+      # - name: Update README version placeholder
+      #   env:
+      #     VERSION: ${{ steps.version.outputs.version }}
+      #   run: |
+      #     node <<'NODE'
+      #     const fs = require('fs');
+      #     const path = 'README.md';
+      #     const version = process.env.VERSION;
+      #     const content = fs.readFileSync(path, 'utf8');
+      #     const updated = content.replace(/__VERSION__/g, version);
+      #     if (content === updated) {
+      #       console.log('No __VERSION__ placeholders found to update.');
+      #     }
+      #     fs.writeFileSync(path, updated);
+      #     NODE
 
-      - name: Commit README update (if needed)
-        env:
-          TAG: ${{ steps.version.outputs.tag }}
-          BRANCH: ${{ github.ref_name }}
-        run: |
-          if git diff --quiet; then
-            echo "No README changes to commit."
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "docs: update README for ${TAG}"
-          git push origin "HEAD:${BRANCH}"
+      # - name: Commit README update (if needed)
+      #   env:
+      #     TAG: ${{ steps.version.outputs.tag }}
+      #     BRANCH: ${{ github.ref_name }}
+      #   run: |
+      #     if git diff --quiet; then
+      #       echo "No README changes to commit."
+      #       exit 0
+      #     fi
+      #     git config user.name "github-actions[bot]"
+      #     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      #     git add README.md
+      #     git commit -m "docs: update README for ${TAG}"
+      #     git push origin "HEAD:${BRANCH}"
 
       - name: Create release
         uses: softprops/action-gh-release@v2

--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ available in the browser version.
 
 **Browser via CDN (no install):**
 
+Substitute the `__VERSION__` below with the release version you are seeking.
+
 - jsDelivr (runtime only):
-  `https://cdn.jsdelivr.net/npm/@gesslar/toolkit@__VERSION__/browser`
+  `https://cdn.jsdelivr.net/npm/@gesslar/toolkit@v__VERSION__/browser`
 - esm.sh (runtime + optional types):
-  `https://esm.sh/@gesslar/toolkit@__VERSION__/browser`
-  `https://esm.sh/@gesslar/toolkit@__VERSION__/browser?dts` (serves `.d.ts` for editors)
+  `https://esm.sh/@gesslar/toolkit@v__VERSION__/browser`
+  `https://esm.sh/@gesslar/toolkit@v__VERSION__/browser?dts` (serves `.d.ts` for editors)
 
 Notes:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",


### PR DESCRIPTION
# Remove automatic README version placeholder updates

This PR makes two key changes:

1. Comments out the GitHub Actions workflow steps that automatically update and commit version placeholders in the README.md file during releases.

2. Updates the README.md to include instructions for users to manually substitute the `__VERSION__` placeholder with their desired release version in CDN URLs.

Additionally, adds the 'v' prefix to version numbers in the CDN URLs to match the correct format for package versioning.

Version bumped to 1.0.2 in package.json.