### PR TITLE
Rename Disposable to Disposer, update API and bump version to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/browser/index.js
+++ b/src/browser/index.js
@@ -3,8 +3,8 @@
 
 export {default as Collection} from "./lib/Collection.js"
 export {default as Data} from "./lib/Data.js"
-export {default as Disposable} from "./lib/Disposable.js"
-export {Disposable as DisposableClass} from "./lib/Disposable.js"
+export {default as Disposer} from "./lib/Disposer.js"
+export {Disposer as DisposerClass} from "./lib/Disposer.js"
 export {default as HTML} from "./lib/HTML.js"
 export {HTML as HTMLClass} from "./lib/HTML.js"
 export {default as Notify} from "./lib/Notify.js"

--- a/src/browser/lib/Disposer.js
+++ b/src/browser/lib/Disposer.js
@@ -2,7 +2,7 @@
  * Simple lifecycle helper that tracks disposer callbacks.
  * Register any teardown functions and call dispose() to run them in reverse.
  */
-export class Disposable {
+export class Disposer {
   #disposers = []
   #disposed = false
 
@@ -12,7 +12,7 @@ export class Disposable {
    * @param {() => void} disposer - Cleanup callback.
    * @returns {() => void} Function to unregister the disposer.
    */
-  registerDisposer(disposer) {
+  register(disposer) {
     if(this.#disposed || typeof disposer !== "function")
       return () => {}
 
@@ -72,4 +72,4 @@ export class Disposable {
   }
 }
 
-export default new Disposable()
+export default new Disposer()

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 // Browser-compatible utilities (pure JS)
 export {default as Collection} from "./browser/lib/Collection.js"
 export {default as Data} from "./browser/lib/Data.js"
-export {default as Disposable} from "./browser/lib/Disposable.js"
-export {Disposable as DisposableClass} from "./browser/lib/Disposable.js"
+export {default as Disposer} from "./browser/lib/Disposer.js"
+export {Disposer as DisposerClass} from "./browser/lib/Disposer.js"
 export {default as Type} from "./browser/lib/TypeSpec.js"
 export {default as Valid} from "./lib/Valid.js"
 

--- a/src/types/browser/index.d.ts
+++ b/src/types/browser/index.d.ts
@@ -6,6 +6,6 @@ export { default as Tantrum } from "./lib/Tantrum.js";
 export { default as Type } from "./lib/TypeSpec.js";
 export { default as Util } from "./lib/Util.js";
 export { default as Valid } from "./lib/Valid.js";
-export { default as Disposable, Disposable as DisposableClass } from "./lib/Disposable.js";
+export { default as Disposer, Disposer as DisposerClass } from "./lib/Disposer.js";
 export { default as HTML, HTML as HTMLClass } from "./lib/HTML.js";
 //# sourceMappingURL=index.d.ts.map

--- a/src/types/browser/lib/Disposable.d.ts
+++ b/src/types/browser/lib/Disposable.d.ts
@@ -2,34 +2,34 @@
  * Simple lifecycle helper that tracks disposer callbacks.
  * Register any teardown functions and call dispose() to run them in reverse.
  */
-export class Disposable {
-    /**
-     * Registers a disposer callback to be executed when disposed.
-     *
-     * @param {() => void} disposer - Cleanup callback.
-     * @returns {() => void} Function to unregister the disposer.
-     */
-    registerDisposer(disposer: () => void): () => void;
-    /**
-     * Runs all registered disposers in reverse order.
-     *
-     * @returns {void}
-     */
-    dispose(): void;
-    /**
-     * Whether disposal has run.
-     *
-     * @returns {boolean} True when dispose() has already been called.
-     */
-    get disposed(): boolean;
-    /**
-     * Read-only list of registered disposers.
-     *
-     * @returns {Array<() => void>} Snapshot of disposer callbacks.
-     */
-    get disposers(): Array<() => void>;
-    #private;
+export class Disposer {
+  /**
+   * Registers a disposer callback to be executed when disposed.
+   *
+   * @param {() => void} disposer - Cleanup callback.
+   * @returns {() => void} Function to unregister the disposer.
+   */
+  register(disposer: () => void): () => void;
+  /**
+   * Runs all registered disposers in reverse order.
+   *
+   * @returns {void}
+   */
+  dispose(): void;
+  /**
+   * Whether disposal has run.
+   *
+   * @returns {boolean} True when dispose() has already been called.
+   */
+  get disposed(): boolean;
+  /**
+   * Read-only list of registered disposers.
+   *
+   * @returns {Array<() => void>} Snapshot of disposer callbacks.
+   */
+  get disposers(): Array<() => void>;
+  #private;
 }
-declare const _default: Disposable;
+declare const _default: Disposer;
 export default _default;
-//# sourceMappingURL=Disposable.d.ts.map
+//# sourceMappingURL=Disposer.d.ts.map

--- a/src/types/browser/lib/Disposable.d.ts.map
+++ b/src/types/browser/lib/Disposable.d.ts.map
@@ -1,1 +1,10 @@
-{"version":3,"file":"Disposable.d.ts","sourceRoot":"","sources":["../../../browser/lib/Disposable.js"],"names":[],"mappings":"AAAA;;;GAGG;AACH;IAIE;;;;;OAKG;IACH,2BAHW,MAAM,IAAI,GACR,MAAM,IAAI,CAStB;IAED;;;;OAIG;IACH,WAFa,IAAI,CAoBhB;IAED;;;;OAIG;IACH,gBAFa,OAAO,CAInB;IAED;;;;OAIG;IACH,iBAFa,KAAK,CAAC,MAAM,IAAI,CAAC,CAI7B;;CAQF"}
+{
+  "version": 3,
+  "file": "Disposer.d.ts",
+  "sourceRoot": "",
+  "sources": [
+    "../../../browser/lib/Disposer.js"
+  ],
+  "names": [],
+  "mappings": "AAAA;;;GAGG;AACH;IAIE;;;;;OAKG;IACH,2BAHW,MAAM,IAAI,GACR,MAAM,IAAI,CAStB;IAED;;;;OAIG;IACH,WAFa,IAAI,CAoBhB;IAED;;;;OAIG;IACH,gBAFa,OAAO,CAInB;IAED;;;;OAIG;IACH,iBAFa,KAAK,CAAC,MAAM,IAAI,CAAC,CAI7B;;CAQF"
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -14,5 +14,5 @@ export { default as Glog } from "./lib/Glog.js";
 export { default as Schemer } from "./lib/Schemer.js";
 export { default as Term } from "./lib/Term.js";
 export { default as Terms } from "./lib/Terms.js";
-export { default as Disposable, Disposable as DisposableClass } from "./browser/lib/Disposable.js";
+export { default as Disposer, Disposer as DisposerClass } from "./browser/lib/Disposer.js";
 //# sourceMappingURL=index.d.ts.map

--- a/src/types/lib/Disposable.d.ts
+++ b/src/types/lib/Disposable.d.ts
@@ -2,32 +2,32 @@
  * Simple lifecycle helper that tracks disposer callbacks.
  * Register any teardown functions and call dispose() to run them in reverse.
  */
-export default class Disposable {
-    /**
-     * Registers a disposer callback to be executed when disposed.
-     *
-     * @param {() => void} disposer - Cleanup callback.
-     * @returns {() => void} Function to unregister the disposer.
-     */
-    registerDisposer(disposer: () => void): () => void;
-    /**
-     * Runs all registered disposers in reverse order.
-     *
-     * @returns {void}
-     */
-    dispose(): void;
-    /**
-     * Whether disposal has run.
-     *
-     * @returns {boolean} True when dispose() has already been called.
-     */
-    get disposed(): boolean;
-    /**
-     * Read-only list of registered disposers.
-     *
-     * @returns {Array<() => void>} Snapshot of disposer callbacks.
-     */
-    get disposers(): Array<() => void>;
-    #private;
+export default class Disposer {
+  /**
+   * Registers a disposer callback to be executed when disposed.
+   *
+   * @param {() => void} disposer - Cleanup callback.
+   * @returns {() => void} Function to unregister the disposer.
+   */
+  register(disposer: () => void): () => void;
+  /**
+   * Runs all registered disposers in reverse order.
+   *
+   * @returns {void}
+   */
+  dispose(): void;
+  /**
+   * Whether disposal has run.
+   *
+   * @returns {boolean} True when dispose() has already been called.
+   */
+  get disposed(): boolean;
+  /**
+   * Read-only list of registered disposers.
+   *
+   * @returns {Array<() => void>} Snapshot of disposer callbacks.
+   */
+  get disposers(): Array<() => void>;
+  #private;
 }
-//# sourceMappingURL=Disposable.d.ts.map
+//# sourceMappingURL=Disposer.d.ts.map

--- a/src/types/lib/Disposable.d.ts.map
+++ b/src/types/lib/Disposable.d.ts.map
@@ -1,1 +1,10 @@
-{"version":3,"file":"Disposable.d.ts","sourceRoot":"","sources":["../../lib/Disposable.js"],"names":[],"mappings":"AAAA;;;GAGG;AACH;IAIE;;;;;OAKG;IACH,2BAHW,MAAM,IAAI,GACR,MAAM,IAAI,CAStB;IAED;;;;OAIG;IACH,WAFa,IAAI,CAoBhB;IAED;;;;OAIG;IACH,gBAFa,OAAO,CAInB;IAED;;;;OAIG;IACH,iBAFa,KAAK,CAAC,MAAM,IAAI,CAAC,CAI7B;;CAQF"}
+{
+  "version": 3,
+  "file": "Disposer.d.ts",
+  "sourceRoot": "",
+  "sources": [
+    "../../lib/Disposer.js"
+  ],
+  "names": [],
+  "mappings": "AAAA;;;GAGG;AACH;IAIE;;;;;OAKG;IACH,2BAHW,MAAM,IAAI,GACR,MAAM,IAAI,CAStB;IAED;;;;OAIG;IACH,WAFa,IAAI,CAoBhB;IAED;;;;OAIG;IACH,gBAFa,OAAO,CAInB;IAED;;;;OAIG;IACH,iBAFa,KAAK,CAAC,MAAM,IAAI,CAAC,CAI7B;;CAQF"
+}

--- a/tests/browser/Disposable.test.js
+++ b/tests/browser/Disposable.test.js
@@ -3,15 +3,15 @@
 import assert from "node:assert/strict"
 import {describe, it} from "node:test"
 
-import {DisposableClass as Disposable} from "@gesslar/toolkit/browser"
+import {DisposerClass as Disposer} from "@gesslar/toolkit/browser"
 
-describe("Disposable", () => {
+describe("Disposer", () => {
   it("runs disposers in reverse order", () => {
     const calls = []
-    const disposable = new Disposable()
+    const disposable = new Disposer()
 
-    disposable.registerDisposer(() => calls.push("first"))
-    disposable.registerDisposer(() => calls.push("second"))
+    disposable.register(() => calls.push("first"))
+    disposable.register(() => calls.push("second"))
 
     disposable.dispose()
 
@@ -20,10 +20,10 @@ describe("Disposable", () => {
 
   it("removes an individual disposer via returned unregister", () => {
     const calls = []
-    const disposable = new Disposable()
+    const disposable = new Disposer()
 
-    const unregister = disposable.registerDisposer(() => calls.push("kept"))
-    disposable.registerDisposer(() => calls.push("removed"))
+    const unregister = disposable.register(() => calls.push("kept"))
+    disposable.register(() => calls.push("removed"))
 
     unregister()
     disposable.dispose()
@@ -32,9 +32,9 @@ describe("Disposable", () => {
   })
 
   it("aggregates errors thrown during disposal", () => {
-    const disposable = new Disposable()
+    const disposable = new Disposer()
 
-    disposable.registerDisposer(() => {
+    disposable.register(() => {
       throw new Error("boom")
     })
 
@@ -47,13 +47,13 @@ describe("Disposable", () => {
   })
 
   it("returns empty disposer when already disposed or invalid input", () => {
-    const disposable = new Disposable()
+    const disposable = new Disposer()
 
-    const noop = disposable.registerDisposer("not a function")
+    const noop = disposable.register("not a function")
     assert.equal(typeof noop, "function")
 
     disposable.dispose()
-    const unregister = disposable.registerDisposer(() => {})
+    const unregister = disposable.register(() => {})
     unregister()
 
     assert.equal(disposable.disposed, true)

--- a/tests/node/Disposable.test.js
+++ b/tests/node/Disposable.test.js
@@ -3,14 +3,14 @@
 import assert from "node:assert/strict"
 import {describe, it} from "node:test"
 
-import {DisposableClass as Disposable} from "@gesslar/toolkit"
+import {DisposerClass as Disposer} from "@gesslar/toolkit"
 
-describe("Disposable (node entry)", () => {
+describe("Disposer (node entry)", () => {
   it("is exported and disposes registered callbacks", () => {
     const calls = []
-    const disposable = new Disposable()
+    const disposable = new Disposer()
 
-    disposable.registerDisposer(() => calls.push("done"))
+    disposable.register(() => calls.push("done"))
     disposable.dispose()
 
     assert.deepEqual(calls, ["done"])


### PR DESCRIPTION
# Rename Disposable to Disposer and Improve API

This PR renames the `Disposable` class to `Disposer` to better reflect its purpose and avoid potential naming conflicts with other libraries. Additionally, the main registration method has been renamed from `registerDisposer()` to the more concise `register()`.

Changes include:
- Renamed `Disposable.js` to `Disposer.js`
- Updated all imports and exports to use the new name
- Renamed `registerDisposer()` method to `register()`
- Updated all tests to use the new class name and method
- Updated TypeScript type definitions
- Bumped package version from 1.3.0 to 1.4.0

This change improves the API's clarity while maintaining the same functionality for tracking and executing cleanup callbacks.