### PR TITLE
Fix DirectoryObject.clone() to use constructor and bump version to 1.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Get in, bitches, we're going toolkitting.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/lib/DirectoryObject.js
+++ b/src/lib/DirectoryObject.js
@@ -459,6 +459,6 @@ export default class DirectoryObject extends FS {
     const thisPath = this.path
     const merged = FS.mergeOverlappingPaths(thisPath, newPath)
 
-    return new this(merged, this.temporary)
+    return new this.constructor(merged, this.temporary)
   }
 }


### PR DESCRIPTION
# Fix DirectoryObject.changePath method to use constructor property

This PR fixes a bug in the `DirectoryObject.changePath` method where it was directly referencing `this` instead of `this.constructor` when creating a new instance. This ensures that when subclasses call this method, they get an instance of their own class rather than the parent `DirectoryObject` class.

Version bumped to 1.9.1 to reflect this bugfix.