### PR TITLE
Enhance error reporting with console grouping and bump version to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "2.2.1",
+  "version": "2.3.0",
   "description": "A collection of utilities for Node.js and browser environments.",
   "main": "./src/index.js",
   "type": "module",

--- a/src/browser/lib/Tantrum.js
+++ b/src/browser/lib/Tantrum.js
@@ -82,21 +82,25 @@ export default class Tantrum extends AggregateError {
    * Reports all aggregated errors to the console with formatted output.
    *
    * @param {boolean} [nerdMode] - Whether to include detailed stack traces
+   * @param {boolean} [isNested] - Whether this is a nested error report
    */
-  report(nerdMode = false) {
-    console.error(
-      `[error] Tantrum Incoming (${this.errors.length} errors)\n` +
+  report(nerdMode = false, isNested = false) {
+    if(isNested)
+      console.error()
+
+    console.group(
+      `[Tantrum Incoming] x${this.errors.length}\n` +
       this.message
     )
 
-    if(this.trace)
+    if(this.trace.length > 0)
       console.error(this.trace.join("\n"))
 
-    console.error()
-
     this.errors.forEach(error => {
-      error.report(nerdMode)
+      error.report(nerdMode, true)
     })
+
+    console.groupEnd()
   }
 
   /**

--- a/src/browser/lib/Util.js
+++ b/src/browser/lib/Util.js
@@ -139,8 +139,8 @@ export default class Util {
    * @param {Array<object>} rejected - Array of rejected results.
    * @throws {Error} Throws a Tantrum error with rejection reasons.
    */
-  static throwRejected(_message="GIGO", rejected) {
-    throw Tantrum.new(this.rejectedReasons(rejected))
+  static throwRejected(message="GIGO", rejected) {
+    throw Tantrum.new(message, this.rejectedReasons(rejected))
   }
 
   /**

--- a/src/lib/Sass.js
+++ b/src/lib/Sass.js
@@ -24,9 +24,13 @@ export default class Sass extends BrowserSass {
    * Optionally includes detailed stack trace information.
    *
    * @param {boolean} [nerdMode] - Whether to include detailed stack trace
+   * @param {boolean} [isNested] - Whether this is a nested error report
    */
-  report(nerdMode=false) {
-    Term.error(
+  report(nerdMode=false, isNested=false) {
+    if(isNested)
+      Term.error()
+
+    Term.group(
       `${Term.terminalBracket(["error", "Something Went Wrong"])}\n` +
       this.trace.join("\n")
     )
@@ -34,16 +38,33 @@ export default class Sass extends BrowserSass {
     if(nerdMode) {
       Term.error(
         "\n" +
-        `${Term.terminalBracket(["error", "Nerd Vittles"])}\n` +
+        `${Term.terminalBracket(["error", "Nerd Victuals"])}\n` +
         this.#fullBodyMassage(this.stack)
       )
-
-      this.cause?.stack && Term.error(
-        "\n" +
-        `${Term.terminalBracket(["error", "Rethrown From"])}\n` +
-        this.#fullBodyMassage(this.cause?.stack)
-      )
     }
+
+    if(this.cause) {
+      if(typeof this.cause.report === "function") {
+        if(nerdMode) {
+          Term.error(
+            "\n" +
+            `${Term.terminalBracket(["error", "Caused By"])}`
+          )
+        }
+
+        this.cause.report(nerdMode, true)
+      } else if(nerdMode && this.cause.stack) {
+        Term.error()
+        Term.group()
+        Term.error(
+          `${Term.terminalBracket(["error", "Rethrown From"])}\n` +
+          this.#fullBodyMassage(this.cause.stack)
+        )
+        Term.groupEnd()
+      }
+    }
+
+    Term.groupEnd()
   }
 
   /**

--- a/src/lib/Tantrum.js
+++ b/src/lib/Tantrum.js
@@ -26,20 +26,24 @@ export default class Tantrum extends BrowserTantrum {
    * Reports all aggregated errors to the terminal with formatted output.
    *
    * @param {boolean} [nerdMode] - Whether to include detailed stack traces
+   * @param {boolean} [isNested] - Whether this is a nested error report
    */
-  report(nerdMode = false) {
-    Term.error(
-      `${Term.terminalBracket(["error", "Tantrum Incoming"])} (${this.errors.length} errors)\n` +
+  report(nerdMode = false, isNested = false) {
+    if(isNested)
+      Term.error()
+
+    Term.group(
+      `${Term.terminalBracket(["error", "Tantrum Incoming"])} x${this.errors.length}\n` +
       this.message
     )
 
-    if(this.trace)
+    if(this.trace.length > 0)
       Term.error(this.trace.join("\n"))
 
-    Term.error()
-
     this.errors.forEach(error => {
-      error.report(nerdMode)
+      error.report(nerdMode, true)
     })
+
+    Term.groupEnd()
   }
 }

--- a/src/lib/Term.js
+++ b/src/lib/Term.js
@@ -50,6 +50,22 @@ export default class Term {
   }
 
   /**
+   * Start a console group for indented output.
+   *
+   * @param {...unknown} [arg] - Optional group label.
+   */
+  static group(...arg) {
+    console.group(...arg)
+  }
+
+  /**
+   * End the current console group.
+   */
+  static groupEnd() {
+    console.groupEnd()
+  }
+
+  /**
    * Emit a status line to the terminal.
    *
    * Accepts either a plain string or an array of message segments (see

--- a/src/types/browser/lib/Util.d.ts
+++ b/src/types/browser/lib/Util.d.ts
@@ -81,7 +81,7 @@ export default class Util {
      *
      * @param {string} [_message] - Optional error message. Defaults to "GIGO"
      * @param {Array<object>} rejected - Array of rejected results.
-     * @throws {Error} Throws a Sass error with rejection reasons.
+     * @throws {Error} Throws a Tantrum error with rejection reasons.
      */
     static throwRejected(_message?: string, rejected: Array<object>): void;
     /**

--- a/tests/browser/Sass.test.js
+++ b/tests/browser/Sass.test.js
@@ -6,19 +6,32 @@ import {Sass} from "@gesslar/toolkit/browser"
 // Helpers for intercepting console output
 /**
  * Captures console output for testing purposes
- * @param {string} method - Console method to capture (e.g., 'error', 'log')
+ * @param {string|string[]} methods - Console method(s) to capture
  * @param {() => void} fn - Function to execute while capturing
  * @returns {string} Captured console output
  */
-function captureConsole(method, fn) {
-  const original = console[method]
+function captureConsole(methods, fn) {
+  const methodList = Array.isArray(methods) ? methods : [methods]
+  const originals = {}
   const calls = []
-  console[method] = (...args) => { calls.push(args.join(" ")) }
+
+  methodList.forEach(method => {
+    originals[method] = console[method]
+    console[method] = (...args) => {
+      if(args.length > 0)
+        calls.push(args.join(" "))
+
+    }
+  })
+
   try {
     fn()
   } finally {
-    console[method] = original
+    methodList.forEach(method => {
+      console[method] = originals[method]
+    })
   }
+
   return calls.join("\n")
 }
 

--- a/tests/node/Term.test.js
+++ b/tests/node/Term.test.js
@@ -184,6 +184,66 @@ describe("Term", () => {
     })
   })
 
+  describe("grouping methods", () => {
+    it("group forwards to console.group with arguments", () => {
+      const calls = captureConsole("group", () => {
+        Term.group("Test Group", 123)
+      })
+
+      assert.equal(calls.length, 1)
+      assert.deepEqual(calls[0], ["Test Group", 123])
+    })
+
+    it("group works with no arguments", () => {
+      const calls = captureConsole("group", () => {
+        Term.group()
+      })
+
+      assert.equal(calls.length, 1)
+      assert.deepEqual(calls[0], [])
+    })
+
+    it("groupEnd forwards to console.groupEnd", () => {
+      const calls = captureConsole("groupEnd", () => {
+        Term.groupEnd()
+      })
+
+      assert.equal(calls.length, 1)
+    })
+
+    it("supports nested groups", () => {
+      const groupCalls = []
+      const groupEndCalls = []
+      const errorCalls = []
+
+      const origGroup = console.group
+      const origGroupEnd = console.groupEnd
+      const origError = console.error
+
+      console.group = (...args) => groupCalls.push(args)
+      console.groupEnd = () => groupEndCalls.push(true)
+      console.error = (...args) => errorCalls.push(args)
+
+      try {
+        Term.group("Outer")
+        Term.error("Message 1")
+        Term.group("Inner")
+        Term.error("Message 2")
+        Term.groupEnd()
+        Term.error("Message 3")
+        Term.groupEnd()
+
+        assert.equal(groupCalls.length, 2)
+        assert.equal(groupEndCalls.length, 2)
+        assert.equal(errorCalls.length, 3)
+      } finally {
+        console.group = origGroup
+        console.groupEnd = origGroupEnd
+        console.error = origError
+      }
+    })
+  })
+
   describe("terminal control methods", () => {
     it("directWrite exists and returns a promise", async () => {
       assert.equal(typeof Term.directWrite, "function")


### PR DESCRIPTION
# Enhanced Error Reporting with Console Groups

This PR improves error reporting in the Sass and Tantrum classes by implementing console grouping for better visual organization of error output. Key changes include:

- Added support for nested error reporting with proper indentation using `console.group` and `console.groupEnd`
- Improved display of chained errors with better visual hierarchy
- Added `isNested` parameter to `report()` methods to handle formatting of nested error reports
- Added `group()` and `groupEnd()` methods to the Term utility class
- Fixed the `throwRejected()` method to properly pass the message parameter to Tantrum
- Changed "Nerd Vittles" to "Nerd Victuals" for more accurate terminology
- Updated error output formatting to show error counts as "x3" instead of "(3 errors)"
- Updated tests to capture and verify grouped console output

Version bumped to 2.3.0 to reflect these new features.