### PR TITLE
Skip quality check when PR creation is not possible

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -23,7 +23,10 @@ jobs:
           # against later. Or just leave empty, implicitly telling this
           # workflow not to wait, just keep swimming.
 
-          echo "quality_check=" >> "$GITHUB_OUTPUT" # skipping because can't PR without it
+          # skipping the QC because you cannot even create a PR without it
+          # having succeeded.
+
+          echo "quality_check=" >> "$GITHUB_OUTPUT"
 
   WaitForQuality:
     needs: ConfigureWorkflow


### PR DESCRIPTION
Update the workflow configuration to skip the quality check when a pull request cannot be created, and clarify the associated comment for better understanding.