### PR TITLE
Update Release workflow to use specific version v1.3.20

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Determine version
         id: check_version
-        uses: gesslar/new-version-questionmark@latest
+        uses: gesslar/new-version-questionmark@v1.3.20
         with:
           source: package.json
           version_pattern: "^v\\d+\\.\\d+\\.\\d+$"


### PR DESCRIPTION
Change the version action in the Release workflow to utilize a specific version instead of the latest.