### PR TITLE
Update file paths and bump version to 3.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.14.0",
+  "version": "3.14.1",
   "license": "Unlicense",
   "homepage": "https://github.com/gesslar/toolkit#readme",
   "repository": {


### PR DESCRIPTION
# Update package paths and version bump to 3.14.1

This PR updates the package structure by:

- Bumping version from 3.14.0 to 3.14.1
- Moving main entry point from `./src/index.js` to `./src/node/index.js`
- Relocating type definitions to a dedicated `types` directory
- Adding separate type definitions for browser and node environments
- Including the `types/` directory in the package files list

These changes improve the package organization by clearly separating node and browser environments with their respective type definitions.