### PR TITLE
Add FileObject.fromCwf() method and bump version to 3.24.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "browser",
     "node"
   ],
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.28.1",
   "main": "./src/node/index.js",
   "type": "module",
   "types": "./types/node/index.d.ts",
@@ -79,11 +79,11 @@
     "yaml": "^2.8.2"
   },
   "devDependencies": {
-    "@gesslar/uglier": "^1.1.0",
+    "@gesslar/uglier": "^1.2.0",
     "eslint": "^9.39.2",
-    "eslint-plugin-jsdoc": "^62.0.0",
-    "happy-dom": "^20.3.1",
+    "eslint-plugin-jsdoc": "^62.3.0",
+    "happy-dom": "^20.3.4",
     "typescript": "^5.9.3",
-    "typescript-eslint": "^8.53.0"
+    "typescript-eslint": "^8.53.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,29 +34,25 @@ importers:
         version: 2.8.2
     devDependencies:
       '@gesslar/uglier':
-        specifier: ^1.1.0
-        version: 1.1.0(eslint@9.39.2)
+        specifier: ^1.2.0
+        version: 1.2.0(eslint@9.39.2)
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
       eslint-plugin-jsdoc:
-        specifier: ^62.0.0
+        specifier: ^62.3.0
         version: 62.3.0(eslint@9.39.2)
       happy-dom:
-        specifier: ^20.3.1
-        version: 20.3.3
+        specifier: ^20.3.4
+        version: 20.3.4
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.53.0
+        specifier: ^8.53.1
         version: 8.53.1(eslint@9.39.2)(typescript@5.9.3)
 
 packages:
-
-  '@es-joy/jsdoccomment@0.78.0':
-    resolution: {integrity: sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw==}
-    engines: {node: '>=20.11.0'}
 
   '@es-joy/jsdoccomment@0.82.0':
     resolution: {integrity: sha512-xs3OTxPefjTZaoDS7H1X2pV33enAmZg+8YldjmeYk7XZnq420phdnp6o0JtrsHBdSRJ5+RTocgyED9TL3epgpw==}
@@ -104,23 +100,18 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@gesslar/colours@0.7.1':
-    resolution: {integrity: sha512-monvp64dwofrQKjW5H/uVLRdNf1iJKoev3TuZG3eWWioSJWY6vT5ZNSXWt7qgHSZimRx1AjPqFZhQYZ1TBq0AA==}
-    engines: {node: '>=22'}
-    hasBin: true
-
   '@gesslar/colours@0.8.0':
     resolution: {integrity: sha512-Sy+xwKAqoE+qVZ/0jvoVRsXEaNMJTc2pEUoyoRYewlAw5k4iLuIGR6cBcZ10W1UvgYTJKxh+462+Eg0QBAx44w==}
     engines: {node: '>=22'}
     hasBin: true
 
-  '@gesslar/toolkit@3.19.0':
-    resolution: {integrity: sha512-XMBzRc933a2nb+XMrrZGx8xLekFf3SBXlxpeX1hPHKOAZOyCT2g6vve/xnAZ47CsTWfeqWD5Qg9ZQpGZMlsquw==}
+  '@gesslar/toolkit@3.23.0':
+    resolution: {integrity: sha512-Y7Ti8qBdJlLoraHGjgdgZkDTEMJH/WNkvWXiw9JCHWJ4n0oeO4HW5XiJBPFsMY1BiftzFNrYAH49DY6a5QLfWw==}
     engines: {node: '>=22'}
 
-  '@gesslar/uglier@1.1.0':
-    resolution: {integrity: sha512-4wEJy8RsHzQ5pCNjigkvD84XRVasQXyJXQVKNH8sVCnpp8On9DGPe7D/6mgDZzXyOlUkZdGOH1pB4x1RuEAfwQ==}
-    engines: {node: '>=22'}
+  '@gesslar/uglier@1.2.0':
+    resolution: {integrity: sha512-YRiaQDXJRQ8tzMCMvejC2k23tGGFvmGshKK19v/0f0zavXGnPYDLx9ILm1FY9GtjyxHOh8diP8P7Xp0eWv8Dow==}
+    engines: {node: '>=22.13'}
     hasBin: true
     peerDependencies:
       eslint: ^9.0.0
@@ -284,10 +275,6 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
-  comment-parser@1.4.1:
-    resolution: {integrity: sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==}
-    engines: {node: '>= 12.0.0'}
-
   comment-parser@1.4.4:
     resolution: {integrity: sha512-0D6qSQ5IkeRrGJFHRClzaMOenMeT0gErz3zIw3AprKMqhRN6LNU2jQOdkPG/FZ+8bCgXE1VidrgSzlBBDZRr8A==}
     engines: {node: '>= 12.0.0'}
@@ -318,12 +305,6 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  eslint-plugin-jsdoc@61.7.1:
-    resolution: {integrity: sha512-36DpldF95MlTX//n3/naULFVt8d1cV4jmSkx7ZKrE9ikkKHAgMLesuWp1SmwpVwAs5ndIM6abKd6PeOYZUgdWg==}
-    engines: {node: '>=20.11.0'}
-    peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0 || ^9.0.0
 
   eslint-plugin-jsdoc@62.3.0:
     resolution: {integrity: sha512-Gc5Ls5qQC6NwqtQTtJ2JE5BwvX348ZCZ+4+QiZ9RpoQ1TCcxFF8Z0E5jaLkTyYNqyhx+uKAvljNHE0B7PBw+iw==}
@@ -433,8 +414,8 @@ packages:
     resolution: {integrity: sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==}
     engines: {node: '>=18'}
 
-  happy-dom@20.3.3:
-    resolution: {integrity: sha512-hM9gltmtQLfmWPqoPreUtRdP3nZCSzQEw7l/JC+up5CxquDykhYFKzIzoFFeVev3AGFEULNvsbE8fpZPgxUYEQ==}
+  happy-dom@20.3.4:
+    resolution: {integrity: sha512-rfbiwB6OKxZFIFQ7SRnCPB2WL9WhyXsFoTfecYgeCeFSOBxvkWLaXsdv5ehzJrfqwXQmDephAKWLRQoFoJwrew==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -474,10 +455,6 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
-
-  jsdoc-type-pratt-parser@7.0.0:
-    resolution: {integrity: sha512-c7YbokssPOSHmqTbSAmTtnVgAVa/7lumWNYqomgd5KOMyPrRve2anx6lonfOsXEQacqF9FKVUj7bLg4vRSvdYA==}
-    engines: {node: '>=20.0.0'}
 
   jsdoc-type-pratt-parser@7.1.0:
     resolution: {integrity: sha512-SX7q7XyCwzM/MEDCYz0l8GgGbJAACGFII9+WfNYr5SLEKukHWRy2Jk3iWRe7P+lpYJNs7oQ+OSei4JtKGUjd7A==}
@@ -690,14 +667,6 @@ packages:
 
 snapshots:
 
-  '@es-joy/jsdoccomment@0.78.0':
-    dependencies:
-      '@types/estree': 1.0.8
-      '@typescript-eslint/types': 8.53.1
-      comment-parser: 1.4.1
-      esquery: 1.7.0
-      jsdoc-type-pratt-parser: 7.0.0
-
   '@es-joy/jsdoccomment@0.82.0':
     dependencies:
       '@types/estree': 1.0.8
@@ -754,25 +723,29 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@gesslar/colours@0.7.1': {}
-
   '@gesslar/colours@0.8.0': {}
 
-  '@gesslar/toolkit@3.19.0':
+  '@gesslar/toolkit@3.23.0(eslint@9.39.2)':
+    dependencies:
+      '@eslint/js': 9.39.2
+      '@gesslar/colours': 0.8.0
+      '@stylistic/eslint-plugin': 5.7.0(eslint@9.39.2)
+      ajv: 8.17.1
+      globals: 17.0.0
+      json5: 2.2.3
+      types: 0.1.1
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - eslint
+
+  '@gesslar/uglier@1.2.0(eslint@9.39.2)':
     dependencies:
       '@gesslar/colours': 0.8.0
-      ajv: 8.17.1
-      json5: 2.2.3
-      yaml: 2.8.2
-
-  '@gesslar/uglier@1.1.0(eslint@9.39.2)':
-    dependencies:
-      '@gesslar/colours': 0.7.1
-      '@gesslar/toolkit': 3.19.0
+      '@gesslar/toolkit': 3.23.0(eslint@9.39.2)
       '@skarab/detect-package-manager': 1.0.0
       '@stylistic/eslint-plugin': 5.7.0(eslint@9.39.2)
       eslint: 9.39.2
-      eslint-plugin-jsdoc: 61.7.1(eslint@9.39.2)
+      eslint-plugin-jsdoc: 62.3.0(eslint@9.39.2)
       globals: 17.0.0
     transitivePeerDependencies:
       - supports-color
@@ -961,8 +934,6 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  comment-parser@1.4.1: {}
-
   comment-parser@1.4.4: {}
 
   concat-map@0.0.1: {}
@@ -982,26 +953,6 @@ snapshots:
   entities@4.5.0: {}
 
   escape-string-regexp@4.0.0: {}
-
-  eslint-plugin-jsdoc@61.7.1(eslint@9.39.2):
-    dependencies:
-      '@es-joy/jsdoccomment': 0.78.0
-      '@es-joy/resolve.exports': 1.2.0
-      are-docs-informative: 0.0.2
-      comment-parser: 1.4.1
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint: 9.39.2
-      espree: 11.1.0
-      esquery: 1.7.0
-      html-entities: 2.6.0
-      object-deep-merge: 2.0.0
-      parse-imports-exports: 0.2.4
-      semver: 7.7.3
-      spdx-expression-parse: 4.0.0
-      to-valid-identifier: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   eslint-plugin-jsdoc@62.3.0(eslint@9.39.2):
     dependencies:
@@ -1139,7 +1090,7 @@ snapshots:
 
   globals@17.0.0: {}
 
-  happy-dom@20.3.3:
+  happy-dom@20.3.4:
     dependencies:
       '@types/node': 25.0.9
       '@types/whatwg-mimetype': 3.0.2
@@ -1177,8 +1128,6 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-
-  jsdoc-type-pratt-parser@7.0.0: {}
 
   jsdoc-type-pratt-parser@7.1.0: {}
 

--- a/src/node/lib/FileSystem.js
+++ b/src/node/lib/FileSystem.js
@@ -80,17 +80,19 @@ export default class FileSystem {
   }
 
   /**
-   * Convert a URI to a path
+   * Convert a file URL to a path.
    *
    * @static
-   * @param {string} pathName - The URI to convert
-   * @returns {string} The path
+   * @param {string} fileUrl - The file URL to convert (e.g., import.meta.url)
+   * @returns {string} The file path
+   * @example
+   * const currentFile = FileSystem.urlToPath(import.meta.url)
    */
-  static urlToPath(pathName) {
+  static urlToPath(fileUrl) {
     try {
-      return url.fileURLToPath(new URL(pathName).pathName)
+      return url.fileURLToPath(fileUrl)
     } catch {
-      return pathName
+      return fileUrl
     }
   }
 

--- a/tests/node/FileObject.test.js
+++ b/tests/node/FileObject.test.js
@@ -1015,4 +1015,33 @@ describe("FileObject", () => {
       })
     })
   })
+
+  describe("fromCwf()", () => {
+    it("returns a FileObject representing the current file", () => {
+      const thisFile = FileObject.fromCwf()
+
+      assert.ok(thisFile instanceof FileObject)
+      assert.ok(thisFile.path.endsWith("FileObject.test.js"))
+    })
+
+    it("returns correct path for the test file", () => {
+      const thisFile = FileObject.fromCwf()
+
+      assert.ok(thisFile.path.includes("tests"))
+      assert.ok(thisFile.path.includes("node"))
+      assert.equal(thisFile.name, "FileObject.test.js")
+    })
+
+    it("returns a FileObject that exists", async () => {
+      const thisFile = FileObject.fromCwf()
+
+      assert.equal(await thisFile.exists, true)
+    })
+
+    it("has correct parent directory", () => {
+      const thisFile = FileObject.fromCwf()
+
+      assert.ok(thisFile.parent.path.endsWith("node"))
+    })
+  })
 })


### PR DESCRIPTION
# Add FileObject.fromCwf() method to get current working file

This PR adds a new static method `FileObject.fromCwf()` that creates a FileObject representing the current working file (the file that called the method). It works by parsing the stack trace to determine the caller's file path.

Key changes:
- Added `FileObject.fromCwf()` method that returns a FileObject for the calling file
- Fixed `FileSystem.urlToPath()` to properly handle file URLs
- Added comprehensive tests for the new functionality
- Updated dependencies and bumped version to 3.24.0

Example usage:
```javascript
// In /home/user/project/src/app.js:
const thisFile = FileObject.fromCwf()
console.log(thisFile.path) // /home/user/project/src/app.js
```

This makes it easier to work with the current file in Node.js applications, especially when dealing with relative paths or when you need to access the current file's metadata.