### PR TITLE
Include scripts/ directory in package files (v3.35.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "3.35.0",
+  "version": "3.35.1",
   "license": "Unlicense",
   "homepage": "https://github.com/gesslar/toolkit#readme",
   "repository": {


### PR DESCRIPTION
Bumped version to 3.35.1 and added the `scripts/` directory to the list of files included in the package.