### PR TITLE
Bump to v5.0.1 and lower Node.js requirement to >=24.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "typescript": "^6.0.2"
       },
       "engines": {
-        "node": ">=24.13.0"
+        "node": ">=24.11.0"
       }
     },
     "node_modules/@astrojs/compiler": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/toolkit",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "LICENSE.txt"
   ],
   "engines": {
-    "node": ">=24.13.0"
+    "node": ">=24.11.0"
   },
   "scripts": {
     "preinstall": "node ./scripts/check-node-version.mjs",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "5.0.0",
+  "version": "5.0.1",
   "license": "0BSD",
   "homepage": "https://github.com/gesslar/toolkit#readme",
   "repository": {


### PR DESCRIPTION
This pull request bumps the package version from 5.0.0 to 5.0.1 and relaxes the minimum Node.js requirement from 24.13.0 to 24.11.0.