### PR TITLE
...

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Includes all browser functionality plus Node.js-specific modules for file I/O, l
 | Valid | Validation and assertion methods |
 | Watcher | File and directory change watcher with debounce protection |
 
-
 ## Installation
 
 ```shell
@@ -151,7 +150,7 @@ Sincerely, Senator Yabba of the Dabba (Doo)
 
 ## License
 
-`@gesslar/toolkit` is released into the public domain under the [0BSD](LICENSE.txt).
+`@gesslar/toolkit` is released under the [0BSD](LICENSE.txt).
 
 This package includes or depends on third-party components under their own
 licenses:


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two minor cleanups to `README.md`: removes a superfluous blank line after the module table, and tightens the license attribution sentence by dropping the phrase "into the public domain."

- **Blank line removal**: cosmetic; no impact.
- **License wording**: the original phrasing "released into the public domain under the [0BSD]" was mildly contradictory — 0BSD is a permissive *license*, not a public domain dedication. Removing "into the public domain" makes the statement more precise.

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no functional impact; safe to merge.

The PR only touches README.md with two trivial edits (blank line removal and a minor wording improvement). No code logic, tests, or configuration is affected.

No files require special attention.

<sub>Reviews (1): Last reviewed commit: ["..."](https://github.com/gesslar/toolkit/commit/b61e3eb98865615e36e01aafc53bca295c1645ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27960749)</sub>

<!-- /greptile_comment -->