### PR TITLE
trying

### DIFF
--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -2,8 +2,8 @@ name: Release
 
 on:
   pull_request:
-    types: [closed]
-    branches: [main]
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   Release:
@@ -12,6 +12,5 @@ jobs:
     secrets: inherit
     with:
       package_manager: auto
-      quality_check: Quality
     permissions:
       contents: write


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two changes to `.github/workflows/Release.yaml`: cosmetic YAML bracket spacing adjustments (`[closed]` → `[ closed ]`, `[main]` → `[ main ]`) and, more significantly, removes the `quality_check: Quality` input from the reusable `Release.yaml@main` workflow call.

- The cosmetic spacing changes have no functional effect.
- Removing `quality_check: Quality` decouples the release workflow from the quality gate — the upstream reusable workflow uses this parameter to know which workflow must pass before a release proceeds. Without it, releases can trigger even if linting or tests failed on the same PR.
- The `uses:` line correctly references `@main` per project convention.

<h3>Confidence Score: 3/5</h3>

Not safe to merge until the intent behind removing `quality_check: Quality` is clarified — it may silently disable the quality gate that guards releases.

The only functional change is the removal of the quality gate reference. If this was accidental it introduces a real release-safety regression; if it was intentional the reasoning isn't documented. The PR title 'trying' suggests this may still be in an exploratory state.

.github/workflows/Release.yaml — specifically the removal of `quality_check: Quality`

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2FRelease.yaml%3A13-15%0A**Quality%20gate%20removed%20from%20release**%0A%0AThe%20%60quality_check%3A%20Quality%60%20parameter%20has%20been%20dropped%20from%20the%20%60with%60%20block.%20In%20the%20upstream%20%60gesslar%2FMaint%2F.github%2Fworkflows%2FRelease.yaml%40main%60%20workflow%2C%20this%20parameter%20is%20used%20to%20reference%20the%20name%20of%20the%20quality-check%20workflow%20that%20must%20pass%20before%20a%20release%20is%20allowed%20to%20proceed.%20Removing%20it%20means%20the%20release%20job%20no%20longer%20waits%20for%20%28or%20enforces%29%20the%20%60Quality%60%20workflow%2C%20so%20a%20merge%20to%20%60main%60%20where%20linting%20or%20tests%20failed%20could%20still%20trigger%20a%20successful%20release.%0A%0AIf%20this%20is%20intentional%20%28e.g.%20the%20upstream%20workflow%20changed%20its%20interface%29%2C%20please%20add%20a%20comment%20explaining%20why%20the%20gate%20was%20dropped.%20If%20it%20was%20removed%20accidentally%2C%20restore%20the%20line%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20package_manager%3A%20auto%0A%20%20%20%20%20%20quality_check%3A%20Quality%0A%20%20%20%20permissions%3A%0A%60%60%60%0A%0A&repo=gesslar%2Ftoolkit&pr=304&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["trying"](https://github.com/gesslar/toolkit/commit/4c25d7e075db5a46782962c1e2e10f403a4b50df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28732843)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - What: Release* and Quality* workflows must target ... ([source](https://app.greptile.com/review/custom-context?memory=c8d8f233-9ea9-4bdc-8096-9102db58bf5b))

<!-- /greptile_comment -->