### PR TITLE
Bump to v5.5.1 with NO_COLOR convention support in Term.hasColor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "5.5.0",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/toolkit",
-      "version": "5.5.0",
+      "version": "5.5.1",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "5.5.0",
+  "version": "5.5.1",
   "license": "0BSD",
   "homepage": "https://github.com/gesslar/toolkit#readme",
   "repository": {

--- a/src/node/lib/Term.js
+++ b/src/node/lib/Term.js
@@ -79,12 +79,27 @@ export default class Term {
   /**
    * Whether the terminal supports color output.
    *
+   * Honours the `NO_COLOR` convention (https://no-color.org): when `NO_COLOR`
+   * is present and not an empty string, colour is disabled. `FORCE_COLOR` takes
+   * precedence over `NO_COLOR` (matching Node/`supports-color`). `supports-color`
+   * itself does not implement `NO_COLOR`, so the check lives here.
+   *
    * @type {boolean}
    */
   static get hasColor() {
-    return this.#cache.has("hasColor")
-      ? this.#cache.get("hasColor")
-      : this.#cache.set("hasColor", Boolean(supportsColor.stdout)).get("hasColor")
+    if(this.#cache.has("hasColor"))
+      return this.#cache.get("hasColor")
+
+    const forced = "FORCE_COLOR" in process.env
+    const noColor = !forced
+      && typeof process.env.NO_COLOR === "string"
+      && process.env.NO_COLOR.length > 0
+
+    const supported = noColor
+      ? false
+      : Boolean(supportsColor.stdout)
+
+    return this.#cache.set("hasColor", supported).get("hasColor")
   }
 
   /**

--- a/tests/node/Term.test.js
+++ b/tests/node/Term.test.js
@@ -380,6 +380,7 @@ describe("Term", () => {
     })
   })
 
+
   describe("data()", () => {
     it("exists and is a function", () => {
       assert.equal(typeof Term.data, "function")


### PR DESCRIPTION
## Honour `NO_COLOR` convention in `Term.hasColor`

The `hasColor` getter now respects the [`NO_COLOR`](https://no-color.org) convention. When the `NO_COLOR` environment variable is present and set to a non-empty string, colour output is disabled.

`FORCE_COLOR` takes precedence over `NO_COLOR`, matching the behaviour of Node.js and `supports-color`. This check is handled explicitly in `Term` because `supports-color` itself does not implement `NO_COLOR`.

Bumps the version to `5.5.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `NO_COLOR` convention support to `Term.hasColor`, with `FORCE_COLOR` taking explicit precedence, and bumps the version to `5.5.1`.

- `hasColor` now checks for `NO_COLOR` (non-empty string) and short-circuits to `false` before consulting `supportsColor`, correctly handling the case that `supports-color` itself does not implement `NO_COLOR`.
- The `FORCE_COLOR` precedence logic and result caching are consistent with the rest of the class.

<h3>Confidence Score: 4/5</h3>

The change is small and the implementation is correct, but the new NO_COLOR/FORCE_COLOR interaction has no dedicated test coverage.

The precedence logic in hasColor looks sound — FORCE_COLOR presence bypasses NO_COLOR, and an empty NO_COLOR is correctly treated as absent. The only gap is that no tests were added for the new branches, meaning a future refactor could silently break the intended behaviour without failing CI.

tests/node/Term.test.js — needs cases for NO_COLOR enabled, NO_COLOR with empty string, and FORCE_COLOR + NO_COLOR together.

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/node/Term.test.js`, line 355-358 ([link](https://github.com/gesslar/toolkit/blob/824de8564786d0ece493828618d29cb0a511a71b/tests/node/Term.test.js#L355-L358)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No tests for new NO_COLOR / FORCE_COLOR logic**

   The new `NO_COLOR` branch is the entire functional change in this PR, but no tests exercise it. The existing `hasColor` test only asserts that the return type is `boolean`. Without dedicated test cases, a regression in the precedence logic (e.g. `FORCE_COLOR` + `NO_COLOR` interaction, or the empty-string edge case) would go undetected. Because `#cache` is static, tests would also need to clear or bypass the cache between cases — worth designing for now rather than after the fact.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fnode%2FTerm.test.js%0ALine%3A%20355-358%0A%0AComment%3A%0A**No%20tests%20for%20new%20NO_COLOR%20%2F%20FORCE_COLOR%20logic**%0A%0AThe%20new%20%60NO_COLOR%60%20branch%20is%20the%20entire%20functional%20change%20in%20this%20PR%2C%20but%20no%20tests%20exercise%20it.%20The%20existing%20%60hasColor%60%20test%20only%20asserts%20that%20the%20return%20type%20is%20%60boolean%60.%20Without%20dedicated%20test%20cases%2C%20a%20regression%20in%20the%20precedence%20logic%20%28e.g.%20%60FORCE_COLOR%60%20%2B%20%60NO_COLOR%60%20interaction%2C%20or%20the%20empty-string%20edge%20case%29%20would%20go%20undetected.%20Because%20%60%23cache%60%20is%20static%2C%20tests%20would%20also%20need%20to%20clear%20or%20bypass%20the%20cache%20between%20cases%20%E2%80%94%20worth%20designing%20for%20now%20rather%20than%20after%20the%20fact.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=gesslar%2Ftoolkit&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Fnode%2FTerm.test.js%3A355-358%0A**No%20tests%20for%20new%20NO_COLOR%20%2F%20FORCE_COLOR%20logic**%0A%0AThe%20new%20%60NO_COLOR%60%20branch%20is%20the%20entire%20functional%20change%20in%20this%20PR%2C%20but%20no%20tests%20exercise%20it.%20The%20existing%20%60hasColor%60%20test%20only%20asserts%20that%20the%20return%20type%20is%20%60boolean%60.%20Without%20dedicated%20test%20cases%2C%20a%20regression%20in%20the%20precedence%20logic%20%28e.g.%20%60FORCE_COLOR%60%20%2B%20%60NO_COLOR%60%20interaction%2C%20or%20the%20empty-string%20edge%20case%29%20would%20go%20undetected.%20Because%20%60%23cache%60%20is%20static%2C%20tests%20would%20also%20need%20to%20clear%20or%20bypass%20the%20cache%20between%20cases%20%E2%80%94%20worth%20designing%20for%20now%20rather%20than%20after%20the%20fact.%0A%0A&repo=gesslar%2Ftoolkit&pr=325&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["5.5.1"](https://github.com/gesslar/toolkit/commit/824de8564786d0ece493828618d29cb0a511a71b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36394958)</sub>

<!-- /greptile_comment -->