### PR TITLE
Bump to v5.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gesslar/toolkit",
-  "version": "5.9.0",
+  "version": "5.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gesslar/toolkit",
-      "version": "5.9.0",
+      "version": "5.9.1",
       "hasInstallScript": true,
       "license": "0BSD",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "name": "gesslar",
     "url": "https://gesslar.dev"
   },
-  "version": "5.9.0",
+  "version": "5.9.1",
   "license": "0BSD",
   "homepage": "https://github.com/gesslar/toolkit#readme",
   "repository": {


### PR DESCRIPTION
Bumps the package version from `5.9.0` to `5.9.1`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the package version consistently from 5.9.0 to 5.9.1.
- Synchronizes the root version in `package.json`.
- Synchronizes both package version entries in `package-lock.json`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only applies a consistent patch-version update across the package manifest and lockfile.

The version metadata is synchronized in all changed locations, with no dependency, script, configuration, or runtime behavior changes.

<sub>Reviews (1): Last reviewed commit: ["5.9.1"](https://github.com/gesslar/toolkit/commit/32cc39ac8a57751c16313b52c606bd7e81810f8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47310432)</sub>

<!-- /greptile_comment -->