### PR TITLE
Run quality checks on all pull requests, not just those targeting main

### DIFF
--- a/.github/workflows/Quality.yaml
+++ b/.github/workflows/Quality.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 jobs:
   Quality:


### PR DESCRIPTION
The CI quality workflow will now trigger on pull requests targeting any branch, rather than being restricted to only pull requests targeting `main`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Quality checks now run for pull requests targeting any branch instead of only `main`.
- Removes the `main` branch filter from the `pull_request` trigger.
- Retains pushes to `main`, manual dispatches, and the reusable quality workflow pinned to `@main`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

Removing the pull-request branch filter validly expands the existing quality workflow to all pull-request target branches while preserving its other triggers and job configuration.

<sub>Reviews (1): Last reviewed commit: ["let CI run on all PRs"](https://github.com/gesslar/toolkit/commit/10823b36fe8e52215647584d9df1061a0acb287d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47311296)</sub>

<!-- /greptile_comment -->